### PR TITLE
Add MANUAL-DEPLOYMENT pipeline

### DIFF
--- a/.github/workflows/MANUAL-DEPLOYMENT.yml
+++ b/.github/workflows/MANUAL-DEPLOYMENT.yml
@@ -1,0 +1,57 @@
+name: MANUAL-DEPLOYMENT
+
+on:
+  workflow_dispatch:
+    inputs:
+      deployment:
+        type: choice
+        required: true
+        description: 'Which JARs to Deploy/Publish?'
+        default: 'all'
+        options:
+          - 'propactive-jvm (Maven Central Repository)'
+          - 'propactive-plugin (Gradle Plugin Portal)'
+          - 'all'
+      version:
+        type: string
+        required: true
+        description: 'Version to release (NOTE: must follow the regular language of: "v[0-9]+.[0-9]+.[0-9]+")'
+
+env:
+  VERSION: ${{ inputs.version }}
+  OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+  OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+  SIGNING_GNUPG_EXECUTABLE: ${{ secrets.SIGNING_GNUPG_EXECUTABLE }}
+  SIGNING_GNUPG_HOME_DIR: ${{ secrets.SIGNING_GNUPG_HOME_DIR }}
+  SIGNING_GNUPG_KEY_NAME: ${{ secrets.SIGNING_GNUPG_KEY_NAME }}
+  SIGNING_GNUPG_PASSPHRASE: ${{ secrets.SIGNING_GNUPG_PASSPHRASE }}
+  SIGNING_GNUPG_PRIVATE_KEY: ${{ secrets.SIGNING_GNUPG_PRIVATE_KEY }}
+  GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+  GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}
+
+jobs:
+  Publish-Jars:
+    needs: Prepare-JARs
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 'Checkout to current branch'
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: 'Set up JDK 17'
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: liberica
+          cache: gradle
+      - name: 'Importing GPG key'
+        uses: crazy-max/ghaction-import-gpg@v5
+        with:
+          gpg_private_key: ${{ env.SIGNING_GNUPG_PRIVATE_KEY }}
+          passphrase: ${{ env.SIGNING_GNUPG_KEY_NAME }}
+      - name: 'Publishing to maven central'
+        if: ${{ input.deployment == 'propactive-jvm (Maven Central Repository)' }} || ${{ input.deployment == 'all' }}
+        run: make publish-propactive-jvm-jars
+      - name: 'Publishing to gradle plugin'
+        if: ${{ input.deployment == 'propactive-plugin (Gradle Plugin Portal)' }} || ${{ input.deployment == 'all' }}
+        run: make publish-propactive-plugin-jars


### PR DESCRIPTION
Adding manual deployment pipeline to allow publishing releases on the go incase of 3rd party failure (which would cause automated release to fail)