### PR TITLE
1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Using the `plugins` & `dependencies` blocks, you can set up Propactive as follow
 
 ```kotlin
 plugins {
-    id("io.github.propactive")
+    id("io.github.propactive") version "1.1.0"
 }
 
 dependencies {
-    implementation("io.github.propactive:propactive-jvm")
+  implementation("io.github.propactive:propactive-jvm:1.1.0")
 }
 ```
 
@@ -60,18 +60,18 @@ then have a look at the rest this guide.
 
 ## Gradle Plugin configurations:
 
-Proactive provides a plugin extension that allows you to specify the destination of the created application properties file,
-set the location of the implementation class, and/or specify which environments you want to generate application properties
+Proactive provides a plugin extension that allows you to specify the destination of created application properties file,
+set the location of implementation class, and/or specify which environments you want to generate application properties
 files for by default. 
 
 Here is an example that generates the files to a directory called `dist` within your build folder, locates the implementation
-class of the application properties object at `propactive.demo.Properties`, and will only generate `prod` environment 
+class of the application properties object at `io.github.propactive.demo.Properties`, and will only generate `prod` environment 
 application properties when no options are passed to the `generateApplicationProperties` task:
 
 ```kotlin
 propactive {
-    destination = layout.buildDirectory.dir("dist").get().asFile.absolutePath
-    implementationClass = "propactive.demo.Properties"
+    destination = layout.buildDirectory.dir("properties").get().asFile.absolutePath
+    implementationClass = "io.github.propactive.demo.Properties"
     environments = "prod"
 }
 ```
@@ -80,18 +80,18 @@ propactive {
 
 [//]: # (TODO: convert to diagram when complete using "Google Draw"...)
 
-In one of the places I worked in, a sum of the projects had a streamlined process to define, test, and maintain application properties.
+In one of the places I worked in, many of our projects had a streamlined process to define, test, and maintain application properties.
 The application source code and deployment details (i.e. helm charts files, application properties, JKS files...etc.)
 were seperated in two different project repositories. This led to the following inconvenience:   
 
 - Duplication: both application project and deployment project are testing against expected properties such as checking for compulsory 
-  keys and typed values (i.e. if a values in an integer as excepted), since we do have several microservices within our stack,
-  these types of tests were duplicated across several projects. 
+  keys and typed values (i.e. if a value in an integer). Since we have several microservices within our stack,
+  these tests were duplicated across several projects. 
 - Maintainability: Since we have multiple environments to deploy our application, we usually end up with many application 
   properties files. We also have a separate module to deploy the application locally (i.e. "dev" environment) and another
   project that we use for E2E integration testing across our stack, so more application properties files were being maintained there.
   This means whenever we add a new application property, the developer needs to be domain-aware of all application property files 
-  and update each, accordingly.       
+  and accordingly update each.       
 - Incoherence: Some application property values are tested to validate if they confirm to a certain type (i.e. URL,
   BASE64, Decimal...etc.). Usually, we have a shared library that extracts common functions and is reused across several 
   projects. However, as the addition/removal of application properties is a fast-paced process, we ended with several 
@@ -130,7 +130,7 @@ app.web.server.url=http://127.0.0.1/
 ```
 
 Usually, this is fine, but as you scale, have many environments, and dozens of application properties that has different
-values for each environment, it becomes more mundane and error-prone, not only you will need to define a constant for 
+values for each environment, it becomes mundane and error-prone, not only you will need to define a constant for 
 `app.web.server.url` to test your property values, and perhaps another constant to reference it on your application side, 
 you will also need to parse each file if you want to test if the URL value is of valid format, if such precision is required.
 
@@ -164,11 +164,11 @@ This will generate a file named `prod-application.properties` with the following
 app.web.server.url=https://www.prodland.com
 ```
 
-On top of that, it will validate the key value as set by type (e.g. `URL`) such that if it's an invalid type, it will 
+On top of that, it will validate the key value set by type (e.g. `URL`), if it's an invalid type, it will 
 fail with a verbose error. For example, the error message below is produced by having a malformed protocol keyword: (i.e. "htps") 
 
 ```log
-Property named: propactive.demo.url.key within environment named: prod was expected to be of type: URL, but value was: htps://www.prodland.com
+Property named: "propactive.demo.url.key" within environment named: "prod" was expected to be of type: "URL", but value was: "htps://www.prodland.com"
 ```
 
 You can have a look below for the [list of natively supported property types](#natively-supported-property-types) or learn 
@@ -195,7 +195,7 @@ Otherwise, please see the next section to learn [how to write your own custom pr
 ## Writing Your Own Custom Property Types
 
 Writing your custom property types is quite straightforward, you just need to implement the `propactive.type.Type` interface, 
-override the `validate` type, return `true` (or the constant `propactive.type.Type.VALID`) when validation pass or `false` (or the constant `propactive.type.Type.INVALID`) 
+override the `validate` type, return `true` (or the constant `io.github.propactive.type.Type.VALID`) when validation pass or `false` (or the constant `io.github.propactive.type.Type.INVALID`) 
 when the validation fails, and then you can use the type within your `@Property` annotation as usual. 
 
 Here is a `PORT_NUMBER` type that you can use to validate if a port number is within a valid range: (i.e. `0 till 65535`)
@@ -277,10 +277,7 @@ have a blank value) This condition can be relaxed by setting the `mandatory` opt
 ```kotlin
 @Environment
 object ApplicationProperties {
-  @Property(
-    value = [""],
-    mandatory = false
-  )
+  @Property(mandatory = false)
   const val property = "propactive.property.key"
 }
 ```

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,13 +94,9 @@ tasks {
 }
 
 fun Jar.withManifestDetails() {
-    manifest {
-        attributes(
-            mapOf(
-                "Implementation-Title" to project.name,
-                "Implementation-Version" to project.version,
-                "Implementation-Vendor" to "Propactive",
-            )
-        )
+    manifest.apply {
+        attributes["Implementation-Title"] = project.name
+        attributes["Implementation-Version"] = project.version
+        attributes["Implementation-Vendor"] = "Propactive"
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,6 @@ subprojects {
         // https://blog.gradle.org/java-toolchains
         toolchain {
             languageVersion.set(JavaLanguageVersion.of(17))
-            vendor.set(JvmVendorSpec.ADOPTOPENJDK)
         }
     }
 }

--- a/propactive-jvm/src/main/kotlin/io/github/propactive/config/constants.kt
+++ b/propactive-jvm/src/main/kotlin/io/github/propactive/config/constants.kt
@@ -4,6 +4,9 @@ package io.github.propactive.config
 internal const val MULTIPLE_ENVIRONMENT_DELIMITER = '/'
 internal const val KEY_VALUE_DELIMITER = ':'
 
+// PROPERTY
+internal const val BLANK_PROPERTY = ""
+
 // ENVIRONMENT
 internal const val UNSPECIFIED_ENVIRONMENT = ""
 internal const val DEFAULT_ENVIRONMENT_FILENAME = "application.properties"

--- a/propactive-jvm/src/main/kotlin/io/github/propactive/file/FileFactory.kt
+++ b/propactive-jvm/src/main/kotlin/io/github/propactive/file/FileFactory.kt
@@ -5,8 +5,11 @@ import java.io.File
 import java.nio.file.Path
 
 object FileFactory {
-    fun create(environment: EnvironmentModel, destination: String) =
-        File(Path.of(destination, environment.filename).toUri())
+    fun create(environment: EnvironmentModel, destination: String, filenameOverride: String? = null) =
+        File(Path.of(
+            destination,
+            if (filenameOverride.isNullOrBlank()) environment.filename else filenameOverride
+        ).toUri())
             .apply { parentFile.mkdirs() }
             .also { file ->
                 environment

--- a/propactive-jvm/src/main/kotlin/io/github/propactive/property/Property.kt
+++ b/propactive-jvm/src/main/kotlin/io/github/propactive/property/Property.kt
@@ -1,5 +1,6 @@
 package io.github.propactive.property
 
+import io.github.propactive.config.BLANK_PROPERTY
 import io.github.propactive.type.STRING
 import io.github.propactive.type.Type
 import kotlin.annotation.AnnotationRetention.RUNTIME
@@ -33,19 +34,19 @@ annotation class Property(
      * ```
      * Will generate an application property for 3 environments (test, stage, and prod)
      */
-    val value: Array<String> = [""],
+    val value: Array<String> = [BLANK_PROPERTY],
     /**
      * The type of the property value. (used on runtime for validation)
      * Current natively supported types:
-     * - BASE64
-     * - BOOLEAN
-     * - DECIMAL
-     * - INTEGER
-     * - JSON
-     * - STRING
-     * - URI
-     * - URL
-     * - UUID
+     * - [io.github.propactive.type.BASE64]
+     * - [io.github.propactive.type.BOOLEAN]
+     * - [io.github.propactive.type.DECIMAL]
+     * - [io.github.propactive.type.INTEGER]
+     * - [io.github.propactive.type.JSON]
+     * - [io.github.propactive.type.STRING]
+     * - [io.github.propactive.type.URI]
+     * - [io.github.propactive.type.URL]
+     * - [io.github.propactive.type.UUID]
      *
      * You can use the interface [Type] to create your own type for custom validation.
      */

--- a/propactive-jvm/src/test/kotlin/io/github/propactive/file/FileFactoryTest.kt
+++ b/propactive-jvm/src/test/kotlin/io/github/propactive/file/FileFactoryTest.kt
@@ -63,6 +63,42 @@ internal class FileFactoryTest {
                 }
         }
 
+        @Test
+        fun shouldOverrideFilenameIfCustomFilenameIsProvided() {
+            val customFilename = Random.alphaNumeric()
+            val environment = mockk<EnvironmentModel>(relaxed = true) {
+                every { filename } returns Random.alphaNumeric()
+            }
+
+            Files
+                .createTempDirectory("")
+                .toFile()
+                .apply { deleteOnExit() }
+                .let { destinationDir ->
+                    FileFactory
+                        .create(environment, destinationDir.absolutePath, customFilename)
+                        .name shouldBe customFilename
+                }
+        }
+
+        @Test
+        fun shouldNotOverrideFilenameIfCustomFilenameIsBlank() {
+            val givenFilename = Random.alphaNumeric()
+            val environment = mockk<EnvironmentModel>(relaxed = true) {
+                every { filename } returns givenFilename
+            }
+
+            Files
+                .createTempDirectory("")
+                .toFile()
+                .apply { deleteOnExit() }
+                .let { destinationDir ->
+                    FileFactory
+                        .create(environment, destinationDir.absolutePath, "")
+                        .name shouldBe givenFilename
+                }
+        }
+
         private fun mockedProperty(number: Int): PropertyModel = mockk {
             every { name } returns "property.name.$number"
             every { value } returns "property.value.$number"

--- a/propactive-jvm/src/test/kotlin/io/github/propactive/property/PropertyFactoryTest.kt
+++ b/propactive-jvm/src/test/kotlin/io/github/propactive/property/PropertyFactoryTest.kt
@@ -1,5 +1,6 @@
 package io.github.propactive.property
 
+import io.github.propactive.config.BLANK_PROPERTY
 import io.github.propactive.config.UNSPECIFIED_ENVIRONMENT
 import io.github.propactive.property.PropertyFailureReason.PROPERTY_FIELD_HAS_INVALID_TYPE
 import io.github.propactive.property.PropertyFailureReason.PROPERTY_FIELD_INACCESSIBLE
@@ -9,11 +10,8 @@ import io.github.propactive.type.INTEGER
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
-import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.*
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
-import org.junit.jupiter.api.assertThrows
 
 @TestInstance(PER_CLASS)
 internal class PropertyFactoryTest {
@@ -110,6 +108,19 @@ internal class PropertyFactoryTest {
                     .create(MandatoryPropertyWithBlankValue::class.members)
             }.message shouldBe PROPERTY_SET_MANDATORY_IS_BLANK("test.resource.value", "")()
         }
+
+        @Test
+        fun `given an object with NonMandatoryPropertyWithBlankValue, when factory creates a DAO, then it should not error`() {
+            assertDoesNotThrow {
+                PropertyFactory
+                    .create(NonMandatoryPropertyWithBlankValue::class.members)
+                    .first().apply {
+                        name shouldBe NonMandatoryPropertyWithBlankValue.PROPERTY_NAME
+                        value shouldBe BLANK_PROPERTY
+                        environment shouldBe UNSPECIFIED_ENVIRONMENT
+                    }
+            }
+        }
     }
 
     // HAPPY PATH OBJECTS
@@ -158,6 +169,11 @@ internal class PropertyFactoryTest {
 
     object MandatoryPropertyWithBlankValue {
         @Property([":"], mandatory = true)
+        const val PROPERTY_NAME = "test.resource.value"
+    }
+
+    object NonMandatoryPropertyWithBlankValue {
+        @Property(mandatory = false)
         const val PROPERTY_NAME = "test.resource.value"
     }
 

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/plugin/Configuration.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/plugin/Configuration.kt
@@ -4,5 +4,6 @@ open class Configuration(
     var environments:        String? = null,
     var implementationClass: String? = null,
     var destination:         String? = null,
+    var filenameOverride:    String? = null,
 )
 

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/plugin/Propactive.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/plugin/Propactive.kt
@@ -3,6 +3,7 @@ package io.github.propactive.plugin
 import io.github.propactive.task.GenerateApplicationProperties
 import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_BUILD_DESTINATION
 import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_ENVIRONMENTS
+import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_FILENAME_OVERRIDE
 import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_IMPLEMENTATION_CLASS
 import io.github.propactive.task.GenerateApplicationPropertiesTask
 import org.gradle.api.Plugin
@@ -38,6 +39,11 @@ open class Propactive : Plugin<Project> {
                             task.destination = propertyOrDefault(
                                 Configuration::destination.name,
                                 (destination ?: DEFAULT_BUILD_DESTINATION)
+                            )
+
+                            task.filenameOverride = propertyOrDefault(
+                                Configuration::filenameOverride.name,
+                                (filenameOverride ?: DEFAULT_FILENAME_OVERRIDE)
                             )
                         }
                     }

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/task/GenerateApplicationProperties.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/task/GenerateApplicationProperties.kt
@@ -1,6 +1,7 @@
 package io.github.propactive.task
 
 import io.github.propactive.environment.EnvironmentFactory
+import io.github.propactive.environment.EnvironmentModel
 import io.github.propactive.file.FileFactory
 import io.github.propactive.plugin.Configuration
 import org.gradle.api.Project
@@ -12,6 +13,7 @@ object GenerateApplicationProperties {
     internal const val DEFAULT_ENVIRONMENTS = "*"
     internal const val DEFAULT_IMPLEMENTATION_CLASS = "ApplicationProperties"
     internal const val DEFAULT_BUILD_DESTINATION = "properties"
+    internal const val DEFAULT_FILENAME_OVERRIDE = ""
 
     internal val TASK_NAME =
         GenerateApplicationProperties::class.simpleName!!.replaceFirstChar(Char::lowercaseChar)
@@ -22,7 +24,7 @@ object GenerateApplicationProperties {
         | -P${Configuration::environments.name}
         |     Description: Comma separated list of environments to generate the properties.
         |     Example: test,stage,prod
-        |     Default: $DEFAULT_ENVIRONMENTS (All provided environment)
+        |     Default: $DEFAULT_ENVIRONMENTS (All provided environments)
         | -P${Configuration::implementationClass.name}
         |     Description: Sets the location of your properties object.
         |     Example: com.package.path.to.your.ApplicationProperties
@@ -31,20 +33,26 @@ object GenerateApplicationProperties {
         |     Description: Sets the location of your generated properties file within the build directory.
         |     Example: path/to/your/desired/location
         |     Default: $DEFAULT_BUILD_DESTINATION (i.e. in a directory called "properties" within your build directory)
+        | -P${Configuration::filenameOverride.name}
+        |     Description: Allows overriding given filename for an environment.
+        |     Example: custom-filename-application.properties
+        |     Note: This should only be used when generating application properties for a singular environment.
     """.trimMargin()
 
     internal fun invoke(
         project: Project,
         environments: String,
         implementationClass: String,
-        destination: String
+        destination: String,
+        filenameOverride: String?,
     ) = project
         .getTasksByName("jar", true)
         .fold(setOf<File>()) { acc, task -> acc.plus(task.outputs.files.files) }
         .findGivenInstanceOf(implementationClass)
         ?.let(EnvironmentFactory::create)
+        ?.requireSingleEnvironmentWhenCustomFilenameIsGiven(environments, filenameOverride)
         ?.filter { environments.contains(it.name) || environments.contains(DEFAULT_ENVIRONMENTS) }
-        ?.forEach { environment -> FileFactory.create(environment, project.layout.buildDirectory.dir(destination).get().asFile.absolutePath) }
+        ?.forEach { environment -> FileFactory.create(environment, project.layout.buildDirectory.dir(destination).get().asFile.absolutePath, filenameOverride) }
         ?: error("Expected to find implementation class $implementationClass")
 
     private fun Set<File>.findGivenInstanceOf(implementationClass: String) = this.firstNotNullOfOrNull {
@@ -52,5 +60,23 @@ object GenerateApplicationProperties {
             .newInstance(arrayOf(URL("jar:file:${it.path}!/")), EnvironmentFactory::class.java.classLoader)
             .runCatching { loadClass(implementationClass).kotlin }
             .getOrNull()
+    }
+
+    private fun Set<EnvironmentModel>?.requireSingleEnvironmentWhenCustomFilenameIsGiven(
+        environments: String,
+        filenameOverride: String?
+    ): Set<EnvironmentModel>? {
+        val propertiesGeneratedForASingularEnvironmentOnly = this?.size == 1
+        val isNotMultiEnvOrWildCardValue = environments
+            .split(",").singleOrNull()?.equals(DEFAULT_ENVIRONMENTS)?.not() ?: false
+
+        require((filenameOverride.isNullOrBlank() || propertiesGeneratedForASingularEnvironmentOnly || isNotMultiEnvOrWildCardValue)) {
+            """
+                Received Property to override filename (-P${Configuration::filenameOverride.name}): $filenameOverride
+                However, this can only be used when a single environment is requested/generated. (Tip: Use -P${Configuration::environments.name} to specify environment application properties to generate)
+            """.trimIndent()
+        }
+
+        return this
     }
 }

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/task/GenerateApplicationProperties.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/task/GenerateApplicationProperties.kt
@@ -2,14 +2,38 @@ package io.github.propactive.task
 
 import io.github.propactive.environment.EnvironmentFactory
 import io.github.propactive.file.FileFactory
-import io.github.propactive.task.GenerateApplicationPropertiesTask.Companion.ENVIRONMENTS_WILDCARD
+import io.github.propactive.plugin.Configuration
 import org.gradle.api.Project
 import java.io.File
 import java.net.URL
 import java.net.URLClassLoader
 
 object GenerateApplicationProperties {
-    fun invoke(
+    internal const val DEFAULT_ENVIRONMENTS = "*"
+    internal const val DEFAULT_IMPLEMENTATION_CLASS = "ApplicationProperties"
+    internal const val DEFAULT_BUILD_DESTINATION = "properties"
+
+    internal val TASK_NAME =
+        GenerateApplicationProperties::class.simpleName!!.replaceFirstChar(Char::lowercaseChar)
+    internal val TASK_DESCRIPTION = """
+        | Generates application properties file for each given environment.
+        |
+        | Optional configurations:
+        | -P${Configuration::environments.name}
+        |     Description: Comma separated list of environments to generate the properties.
+        |     Example: test,stage,prod
+        |     Default: $DEFAULT_ENVIRONMENTS (All provided environment)
+        | -P${Configuration::implementationClass.name}
+        |     Description: Sets the location of your properties object.
+        |     Example: com.package.path.to.your.ApplicationProperties
+        |     Default: $DEFAULT_IMPLEMENTATION_CLASS (at the root of your project)
+        | -P${Configuration::destination.name}
+        |     Description: Sets the location of your generated properties file within the build directory.
+        |     Example: path/to/your/desired/location
+        |     Default: $DEFAULT_BUILD_DESTINATION (i.e. in a directory called "properties" within your build directory)
+    """.trimMargin()
+
+    internal fun invoke(
         project: Project,
         environments: String,
         implementationClass: String,
@@ -19,8 +43,8 @@ object GenerateApplicationProperties {
         .fold(setOf<File>()) { acc, task -> acc.plus(task.outputs.files.files) }
         .findGivenInstanceOf(implementationClass)
         ?.let(EnvironmentFactory::create)
-        ?.filter { environments.contains(it.name) || environments.contains(ENVIRONMENTS_WILDCARD) }
-        ?.forEach { environment -> FileFactory.create(environment, destination) }
+        ?.filter { environments.contains(it.name) || environments.contains(DEFAULT_ENVIRONMENTS) }
+        ?.forEach { environment -> FileFactory.create(environment, project.layout.buildDirectory.dir(destination).get().asFile.absolutePath) }
         ?: error("Expected to find implementation class $implementationClass")
 
     private fun Set<File>.findGivenInstanceOf(implementationClass: String) = this.firstNotNullOfOrNull {

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/task/GenerateApplicationPropertiesTask.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/task/GenerateApplicationPropertiesTask.kt
@@ -1,6 +1,6 @@
 package io.github.propactive.task
 
-import io.github.propactive.plugin.Configuration
+import io.github.propactive.plugin.Propactive
 import io.github.propactive.task.GenerateApplicationProperties.invoke
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
@@ -9,19 +9,13 @@ import org.gradle.api.tasks.TaskAction
 
 open class GenerateApplicationPropertiesTask : DefaultTask() {
     @get:Input
-    internal var environments = project
-        .propertyOrDefault(Configuration::environments.name, ENVIRONMENTS_WILDCARD)
+    internal lateinit var environments: String
 
     @get:Input
-    internal var implementationClass = project
-        .propertyOrDefault(Configuration::implementationClass.name, DEFAULT_IMPLEMENTATION_CLASS)
+    internal lateinit var implementationClass: String
 
     @get:Input
-    internal var destination = project
-        .propertyOrDefault(
-            Configuration::destination.name,
-            project.layout.buildDirectory.dir(DEFAULT_BUILD_DESTINATION).get().asFile.absolutePath
-        )
+    internal lateinit var destination: String
 
     @TaskAction
     fun run() = project
@@ -29,35 +23,9 @@ open class GenerateApplicationPropertiesTask : DefaultTask() {
         .run { invoke(project, environments, implementationClass, destination) }
 
     init {
-        group = "propactive"
-        description = """
-            | Generates application properties file for each given environment.
-            |
-            | Optional configurations:
-            | -P${Configuration::environments.name}
-            |     Description: Comma separated list of environments to generate the properties.
-            |     Example: test,stage,prod
-            |     Default: $ENVIRONMENTS_WILDCARD (All provided environment)
-            | -P${Configuration::implementationClass.name}
-            |     Description: Sets the location of your properties object.
-            |     Example: com.package.path.to.your.ApplicationProperties
-            |     Default: $implementationClass (at the root of your project)
-            | -P${Configuration::destination.name}
-            |     Description: Sets the location of your generated properties file.
-            |     Example: path/to/your/desired/location
-            |     Default: $destination (in a directory called "dist" within your build directory)
-        """.trimMargin()
+        group = Propactive::class.simpleName!!.lowercase()
+        description = GenerateApplicationProperties.TASK_DESCRIPTION
     }
-
-    companion object {
-        internal const val ENVIRONMENTS_WILDCARD = "*"
-        internal const val DEFAULT_IMPLEMENTATION_CLASS = "ApplicationProperties"
-        internal const val DEFAULT_BUILD_DESTINATION = "dist"
-    }
-
-    private fun Project.propertyOrDefault(propertyName: String, default: String) = default
-        .takeUnless { hasProperty(propertyName) }
-        ?: "${property(propertyName)}"
 
     private fun Project.logConfigurationsValues(): Project = this.also { project ->
         project.logger.debug(

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/task/GenerateApplicationPropertiesTask.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/task/GenerateApplicationPropertiesTask.kt
@@ -1,5 +1,6 @@
 package io.github.propactive.task
 
+import io.github.propactive.plugin.Configuration
 import io.github.propactive.plugin.Propactive
 import io.github.propactive.task.GenerateApplicationProperties.invoke
 import org.gradle.api.DefaultTask
@@ -17,10 +18,13 @@ open class GenerateApplicationPropertiesTask : DefaultTask() {
     @get:Input
     internal lateinit var destination: String
 
+    @get:Input
+    internal lateinit var filenameOverride: String
+
     @TaskAction
     fun run() = project
         .logConfigurationsValues()
-        .run { invoke(project, environments, implementationClass, destination) }
+        .run { invoke(project, environments, implementationClass, destination, filenameOverride) }
 
     init {
         group = Propactive::class.simpleName!!.lowercase()
@@ -31,11 +35,11 @@ open class GenerateApplicationPropertiesTask : DefaultTask() {
         project.logger.debug(
             """
             |
-            | Propactive - Received the following configurations:
-            |  - environments        = $environments 
-            |  - implementationClass = $implementationClass
-            |  - destination         = $destination
-            |
+            | Propactive ${GenerateApplicationProperties.TASK_NAME} - Received the following configurations:
+            |  - ${Configuration::environments.name} = $environments 
+            |  - ${Configuration::implementationClass.name} = $implementationClass
+            |  - ${Configuration::destination.name} = $destination
+            |  - ${Configuration::filenameOverride.name} = $filenameOverride
             """.trimMargin()
         )
     }

--- a/propactive-plugin/src/test/kotlin/io/github/propactive/plugin/ConfigurationTest.kt
+++ b/propactive-plugin/src/test/kotlin/io/github/propactive/plugin/ConfigurationTest.kt
@@ -14,6 +14,7 @@ internal class ConfigurationTest {
             environments.shouldBeNull()
             implementationClass.shouldBeNull()
             destination.shouldBeNull()
+            filenameOverride.shouldBeNull()
         }
     }
 
@@ -22,24 +23,29 @@ internal class ConfigurationTest {
         val environmentsNewValue = "${randomUUID()}"
         val implementationClassNewValue = "${randomUUID()}"
         val destinationNewValue = "${randomUUID()}"
+        val filenameOverrideNewValue = "${randomUUID()}"
 
         Configuration()
             .apply {
                 environments = "${randomUUID()}"
                 implementationClass = "${randomUUID()}"
                 destination = "${randomUUID()}"
+                filenameOverride = "${randomUUID()}"
             }.apply {
                 environments.shouldNotBeNull()
                 implementationClass.shouldNotBeNull()
                 destination.shouldNotBeNull()
+                filenameOverride.shouldNotBeNull()
             }.apply {
                 environments = environmentsNewValue
                 implementationClass = implementationClassNewValue
                 destination = destinationNewValue
+                filenameOverride = filenameOverrideNewValue
             }.apply {
                 environments shouldBe environmentsNewValue
                 implementationClass shouldBe implementationClassNewValue
                 destination shouldBe destinationNewValue
+                filenameOverride shouldBe filenameOverrideNewValue
             }
     }
 }

--- a/propactive-plugin/src/test/kotlin/io/github/propactive/plugin/PropactiveTest.kt
+++ b/propactive-plugin/src/test/kotlin/io/github/propactive/plugin/PropactiveTest.kt
@@ -1,18 +1,27 @@
 package io.github.propactive.plugin
 
 import io.github.propactive.task.GenerateApplicationProperties
+import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_BUILD_DESTINATION
+import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_ENVIRONMENTS
+import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_IMPLEMENTATION_CLASS
 import io.github.propactive.task.GenerateApplicationPropertiesTask
 import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.matchers.collections.shouldNotBeEmpty
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.mockk
 import io.mockk.verify
 import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.UnexpectedBuildFailure
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS
 import java.io.File
 import java.nio.file.Files
+import java.util.*
 import kotlin.text.RegexOption.DOT_MATCHES_ALL
 
 class PropactiveTest {
@@ -48,6 +57,132 @@ class PropactiveTest {
                         any()
                     )
             }
+        }
+    }
+
+    @Nested
+    inner class Acceptance {
+        private lateinit var project: Project
+
+        @BeforeEach
+        internal fun setUp() {
+            project = ProjectBuilder.builder()
+                .withName("temporary-project-${UUID.randomUUID()}")
+                .build()
+                .also { p -> p.plugins.apply(Propactive::class.java) }
+        }
+
+        @Test
+        fun `should register task to generate application properties`() {
+            project
+                .getTasksByName(GenerateApplicationProperties.TASK_NAME, false)
+                .shouldNotBeEmpty()
+                .first()
+                .shouldBeInstanceOf<GenerateApplicationPropertiesTask>()
+        }
+
+        @Test
+        fun `should provide sane propactive configuration defaults`() {
+            project
+                .getTasksByName(GenerateApplicationProperties.TASK_NAME, false)
+                .first()
+                .let { it as GenerateApplicationPropertiesTask }
+                .apply {
+                    destination shouldBe DEFAULT_BUILD_DESTINATION
+                    environments shouldBe DEFAULT_ENVIRONMENTS
+                    implementationClass shouldBe DEFAULT_IMPLEMENTATION_CLASS
+                }
+        }
+
+        @Test
+        fun `should register task extension to configure propactive`() {
+            project
+                .extensions
+                .findByType(Configuration::class.java)
+                .shouldNotBeNull()
+        }
+
+        @Test
+        fun `should allow modifying propactive configurations`() {
+            val customDestination = "custom/path"
+            val customEnvironments = "test"
+            val customImplementationClass = "io.github.propactive.Test"
+
+            project
+                .extensions
+                .findByType(Configuration::class.java)!!
+                .apply {
+                    destination = customDestination
+                    environments = customEnvironments
+                    implementationClass = customImplementationClass
+                }
+
+            project
+                .getTasksByName(GenerateApplicationProperties.TASK_NAME, false)
+                .first()
+                .let { it as GenerateApplicationPropertiesTask }
+                .apply {
+                    destination shouldBe customDestination
+                    environments shouldBe customEnvironments
+                    implementationClass shouldBe customImplementationClass
+                }
+        }
+
+        @Test
+        fun `should allow setting propactive configurations through system property`() {
+            val customDestination = "custom/path"
+            val customEnvironments = "test"
+            val customImplementationClass = "io.github.propactive.Test"
+
+            project
+                .getTasksByName(GenerateApplicationProperties.TASK_NAME, false)
+                .first()
+                .let { it as GenerateApplicationPropertiesTask }
+                .apply {
+                    setProperty(Configuration::destination.name, customDestination)
+                    setProperty(Configuration::environments.name, customEnvironments)
+                    setProperty(Configuration::implementationClass.name, customImplementationClass)
+                }
+                .apply {
+                    destination shouldBe customDestination
+                    environments shouldBe customEnvironments
+                    implementationClass shouldBe customImplementationClass
+                }
+        }
+
+        @Test
+        fun `should allow overriding propactive configurations`() {
+            val customConfigDestination = "custom/path/config"
+            val customConfigEnvironments = "testConfig"
+            val customConfigImplementationClass = "io.github.propactive.TestConfig"
+
+            val customPropertyDestination = "custom/path/Property"
+            val customPropertyEnvironments = "testProperty"
+            val customPropertyImplementationClass = "io.github.propactive.TestProperty"
+
+            project
+                .extensions
+                .findByType(Configuration::class.java)!!
+                .apply {
+                    destination = customConfigDestination
+                    environments = customConfigEnvironments
+                    implementationClass = customConfigImplementationClass
+                }
+
+            project
+                .getTasksByName(GenerateApplicationProperties.TASK_NAME, false)
+                .first()
+                .let { it as GenerateApplicationPropertiesTask }
+                .apply {
+                    setProperty(Configuration::destination.name, customPropertyDestination)
+                    setProperty(Configuration::environments.name, customPropertyEnvironments)
+                    setProperty(Configuration::implementationClass.name, customPropertyImplementationClass)
+                }
+                .apply {
+                    destination shouldBe customPropertyDestination
+                    environments shouldBe customPropertyEnvironments
+                    implementationClass shouldBe customPropertyImplementationClass
+                }
         }
     }
 
@@ -110,7 +245,7 @@ class PropactiveTest {
                             | }
                             | 
                             | propactive {
-                            |     destination = layout.buildDirectory.dir("dist").get().asFile.absolutePath
+                            |     destination = layout.buildDirectory.dir("properties").get().asFile.absolutePath
                             |     implementationClass = "propactive.dev.Properties"
                             |     environments = "dev"
                             | }

--- a/propactive-plugin/src/test/kotlin/io/github/propactive/plugin/PropactiveTest.kt
+++ b/propactive-plugin/src/test/kotlin/io/github/propactive/plugin/PropactiveTest.kt
@@ -133,6 +133,7 @@ class PropactiveTest {
             val customDestination = "custom/path"
             val customEnvironments = "test"
             val customImplementationClass = "io.github.propactive.Test"
+            val customFilename = "customFilename"
 
             project
                 .getTasksByName(GenerateApplicationProperties.TASK_NAME, false)
@@ -142,11 +143,13 @@ class PropactiveTest {
                     setProperty(Configuration::destination.name, customDestination)
                     setProperty(Configuration::environments.name, customEnvironments)
                     setProperty(Configuration::implementationClass.name, customImplementationClass)
+                    setProperty(Configuration::filenameOverride.name, customFilename)
                 }
                 .apply {
                     destination shouldBe customDestination
                     environments shouldBe customEnvironments
                     implementationClass shouldBe customImplementationClass
+                    filenameOverride shouldBe customFilename
                 }
         }
 

--- a/propactive-plugin/src/test/kotlin/io/github/propactive/task/GenerateApplicationPropertiesTest.kt
+++ b/propactive-plugin/src/test/kotlin/io/github/propactive/task/GenerateApplicationPropertiesTest.kt
@@ -1,10 +1,13 @@
 package io.github.propactive.task
 
 import io.github.propactive.environment.Environment
+import io.github.propactive.plugin.Configuration
 import io.github.propactive.property.Property
 import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_BUILD_DESTINATION
 import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_ENVIRONMENTS
+import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_FILENAME_OVERRIDE
 import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_IMPLEMENTATION_CLASS
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -14,8 +17,10 @@ import org.gradle.api.Task
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.fail
+import java.io.File
 import java.net.URLClassLoader
 import java.nio.file.Files
+import java.util.*
 
 internal class GenerateApplicationPropertiesTest {
     @Test
@@ -33,16 +38,104 @@ internal class GenerateApplicationPropertiesTest {
                 project,
                 DEFAULT_ENVIRONMENTS,
                 DEFAULT_IMPLEMENTATION_CLASS,
-                DEFAULT_BUILD_DESTINATION
+                DEFAULT_BUILD_DESTINATION,
+                DEFAULT_FILENAME_OVERRIDE
             )
         }.message shouldBe "Expected to find implementation class $DEFAULT_IMPLEMENTATION_CLASS"
     }
 
     @Test
     fun shouldCreatePropertyFilesWhenImplementationClassIsFound() {
+        setupScenario(WithMultipleEnvironments::class.java) { project, buildDir ->
+            val implementationClass =
+                "io.github.propactive.task.GenerateApplicationPropertiesTest.WithMultipleEnvironments"
+
+            GenerateApplicationProperties.invoke(
+                project,
+                DEFAULT_ENVIRONMENTS,
+                implementationClass,
+                buildDir.absolutePath,
+                DEFAULT_FILENAME_OVERRIDE
+            )
+
+            buildDir.listFiles()?.apply {
+                count() shouldBe 2
+                sortBy { it.name }
+            }?.forEachIndexed { index, file ->
+                file.name shouldBe "env$index-application.properties"
+                file?.readLines()?.first() shouldBe "test.resource.value=env${index}Value"
+            } ?: fail("Expected to find 2 property files")
+        }
+    }
+
+    @Test
+    fun shouldAllowApplicationPropertiesFilenameOverrideWhenASingularEnvironmentApplicationPropertiesHasBeenGenerated() {
+        setupScenario(WithSingularEnvironment::class.java) { project, buildDir ->
+            val implementationClass =
+                "io.github.propactive.task.GenerateApplicationPropertiesTest.WithSingularEnvironment"
+
+            val customFilename = "${UUID.randomUUID()}-application.properties"
+
+            GenerateApplicationProperties.invoke(
+                project,
+                DEFAULT_ENVIRONMENTS,
+                implementationClass,
+                buildDir.absolutePath,
+                customFilename
+            )
+
+            buildDir
+                .listFiles()
+                ?.single()
+                ?.apply {
+                    name shouldBe customFilename
+                    readLines().first() shouldBe "test.resource.value=envValue"
+                }
+        }
+    }
+
+    @Test
+    fun shouldFailIfApplicationPropertiesFilenameIsSuppliedWhenMoreThanOneEnvironmentIsRequested() {
+        setupScenario(WithMultipleEnvironments::class.java) { project, buildDir ->
+            val implementationClass =
+                "io.github.propactive.task.GenerateApplicationPropertiesTest.WithMultipleEnvironments"
+
+            val customFilename = "${UUID.randomUUID()}-application.properties"
+
+            shouldThrow<IllegalArgumentException> {
+                GenerateApplicationProperties.invoke(
+                    project,
+                    DEFAULT_ENVIRONMENTS,
+                    implementationClass,
+                    buildDir.absolutePath,
+                    customFilename
+                )
+            }.message shouldBe """
+                Received Property to override filename (-P${Configuration::filenameOverride.name}): $customFilename
+                However, this can only be used when a single environment is requested/generated. (Tip: Use -P${Configuration::environments.name} to specify environment application properties to generate)
+            """.trimIndent()
+        }
+    }
+
+    @Environment
+    object WithSingularEnvironment {
+        @Property(["envValue"])
+        const val property = "test.resource.value"
+    }
+
+    @Environment(["env0: env0-application.properties", "env1: env1-application.properties"])
+    object WithMultipleEnvironments {
+        @Property(["env0:env0Value", "env1:env1Value"])
+        const val property = "test.resource.value"
+    }
+
+    private fun setupScenario(
+        propertiesClass: Class<*>,
+        callback: (Project, File) -> Unit
+    ) {
         mockkStatic(URLClassLoader::class) {
             val buildDir = Files
-                .createTempDirectory("tmp")
+                .createTempDirectory(DEFAULT_BUILD_DESTINATION)
                 .toFile().apply { deleteOnExit() }
 
             val task = mockk<Task> {
@@ -51,35 +144,16 @@ internal class GenerateApplicationPropertiesTest {
 
             val project = mockk<Project>() {
                 every { getTasksByName("jar", true) } returns setOf(task)
-                every<String> { layout.buildDirectory.dir(buildDir.absolutePath).get().asFile.absolutePath } returns buildDir.absolutePath
+                every<String> {
+                    layout.buildDirectory.dir(buildDir.absolutePath).get().asFile.absolutePath
+                } returns buildDir.absolutePath
             }
 
             every { URLClassLoader.newInstance(any(), any()) } returns mockk {
-                every { loadClass(any()) } returns WithDifferentEnvironmentValues::class.java
+                every { loadClass(any()) } returns propertiesClass
             }
 
-            GenerateApplicationProperties.invoke(
-                project,
-                DEFAULT_ENVIRONMENTS,
-                DEFAULT_IMPLEMENTATION_CLASS,
-                buildDir.absolutePath
-            )
-
-            buildDir.listFiles().apply {
-                this?.apply {
-                    count() shouldBe 2
-                    sortBy { it.name }
-                }?.forEachIndexed { index, file ->
-                    file.name shouldBe "env$index-application.properties"
-                    file?.readLines()?.first() shouldBe "test.resource.value=env${index}Value"
-                } ?: fail("Expected to find 2 property files")
-            }
+            callback.invoke(project, buildDir)
         }
-    }
-
-    @Environment(["env0: env0-application.properties", "env1: env1-application.properties"])
-    object WithDifferentEnvironmentValues {
-        @Property(["env0:env0Value", "env1:env1Value"])
-        const val property = "test.resource.value"
     }
 }

--- a/propactive-plugin/src/test/kotlin/io/github/propactive/task/GenerateApplicationPropertiesTest.kt
+++ b/propactive-plugin/src/test/kotlin/io/github/propactive/task/GenerateApplicationPropertiesTest.kt
@@ -2,9 +2,9 @@ package io.github.propactive.task
 
 import io.github.propactive.environment.Environment
 import io.github.propactive.property.Property
-import io.github.propactive.task.GenerateApplicationPropertiesTask.Companion.DEFAULT_BUILD_DESTINATION
-import io.github.propactive.task.GenerateApplicationPropertiesTask.Companion.DEFAULT_IMPLEMENTATION_CLASS
-import io.github.propactive.task.GenerateApplicationPropertiesTask.Companion.ENVIRONMENTS_WILDCARD
+import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_BUILD_DESTINATION
+import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_ENVIRONMENTS
+import io.github.propactive.task.GenerateApplicationProperties.DEFAULT_IMPLEMENTATION_CLASS
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
@@ -31,7 +31,7 @@ internal class GenerateApplicationPropertiesTest {
         assertThrows<IllegalStateException> {
             GenerateApplicationProperties.invoke(
                 project,
-                ENVIRONMENTS_WILDCARD,
+                DEFAULT_ENVIRONMENTS,
                 DEFAULT_IMPLEMENTATION_CLASS,
                 DEFAULT_BUILD_DESTINATION
             )
@@ -49,8 +49,9 @@ internal class GenerateApplicationPropertiesTest {
                 every { outputs.files.files } returns setOf(mockk(relaxed = true))
             }
 
-            val project = mockk<Project> {
+            val project = mockk<Project>() {
                 every { getTasksByName("jar", true) } returns setOf(task)
+                every<String> { layout.buildDirectory.dir(buildDir.absolutePath).get().asFile.absolutePath } returns buildDir.absolutePath
             }
 
             every { URLClassLoader.newInstance(any(), any()) } returns mockk {
@@ -59,7 +60,7 @@ internal class GenerateApplicationPropertiesTest {
 
             GenerateApplicationProperties.invoke(
                 project,
-                ENVIRONMENTS_WILDCARD,
+                DEFAULT_ENVIRONMENTS,
                 DEFAULT_IMPLEMENTATION_CLASS,
                 buildDir.absolutePath
             )


### PR DESCRIPTION
### Changes
- Add feature to override filename for singular environments for when user wants granular control within their CICD pipeline.
- Fix bug where Propactive configurations were not being overridden when user provide System properties to do so.
- Apply changes on the mutable instance instead of creating a new Manifest.
- Improve README documentation.
- Introduce BLANK_PROPERTY constant.
- Set Java vendor spec to be agnostic.