### PR TITLE
[gradle refresh versions bot]

### DIFF
--- a/.github/workflows/REFRESH_VERSIONS.yml
+++ b/.github/workflows/REFRESH_VERSIONS.yml
@@ -1,0 +1,50 @@
+name: REFRESH_VERSIONS
+
+on: workflow_dispatch
+
+jobs:
+  "Refresh-Versions":
+    runs-on: ubuntu-20.04
+    steps:
+      - id: step-0
+        name: check-out
+        uses: actions/checkout@v3
+        with:
+          ref: main
+      - id: step-1
+        name: setup-java
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: adopt
+      - id: step-2
+        name: create-branch
+        uses: peterjgrainger/action-create-branch@v2.2.0
+        with:
+          branch: dependency-update
+        env:
+          GITHUB_TOKEN: {{ secrets.GITHUB_TOKEN }}
+      - id: step-3
+        name: gradle refreshVersions
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: refreshVersions
+      - id: step-4
+        name: Commit
+        uses: EndBug/add-and-commit@v9
+        with:
+          author_name: GitHub Actions
+          author_email: noreply@github.com
+          message: Refresh versions.properties
+          new_branch: dependency-update
+          push: --force --set-upstream origin dependency-update
+      - id: step-5
+        name: Pull Request
+        uses: repo-sync/pull-request@v2
+        with:
+          source_branch: dependency-update
+          destination_branch: main
+          pr_title: Upgrade gradle dependencies
+          pr_body: '[refreshVersions](https://github.com/jmfayard/refreshVersions) has found those library updates!'
+          pr_draft: true
+          github_token: {{ secrets.GITHUB_TOKEN }}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -2,3 +2,8 @@ include(
     ":propactive-plugin",
     ":propactive-jvm",
 )
+plugins {
+    // See https://jmfayard.github.io/refreshVersions
+    id("de.fayard.refreshVersions") version "0.50.2"
+}
+


### PR DESCRIPTION
Solves https://github.com/propactive/propactive/issues/21 

- added refresh versions dependency
- added new manual workflow: REFRESH_VERSIONS.yml

Regarding the [organized dependency notations](https://jmfayard.github.io/refreshVersions/add-dependencies/#use-built-in-dependency-notations), I found out that there is only a limited [set of libraries](https://github.com/jmfayard/refreshVersions/tree/main/plugins/dependencies/src/main/kotlin/dependencies) for which this is supported. I wasn't able to find any of the libraries used in the project