### PR TITLE
#8 improve release pipeline

### DIFF
--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -36,6 +36,15 @@ jobs:
     steps:
       - name: 'Checkout to current branch'
         uses: actions/checkout@v3
+        with:
+          ref: main
+          # Use a scope-restricted (bot) account to bypass branch protection limitations
+          # see: https://github.com/community/community/discussions/13836
+          token: ${{ secrets.PROPACTIVE_BOT_ACCESS_TOKEN }}
+      - name: 'Set Git environment for automated README.md push requirements'
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
       - name: 'Update README.md documentation to latest release version'
         run: make update-readme-documented-versions
       - name: 'commit the updated README.md'

--- a/.github/workflows/RELEASE.yml
+++ b/.github/workflows/RELEASE.yml
@@ -27,7 +27,7 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             https://api.github.com/repos/${{ github.repository }}/releases \
-            -d '{"tag_name":"${{ steps.tag_deriver.outputs.LATEST_TAG }}","name":"${{ steps.tag_deriver.outputs.LATEST_TAG }}","draft":true,"generate_release_notes":true}'
+            -d '{"draft":true,"tag_name":"${{ steps.tag_deriver.outputs.LATEST_TAG }}","name":"${{ steps.tag_deriver.outputs.LATEST_TAG }}","generate_release_notes":true,"body":"### Deployment:\n * Gradle Plugin Portal: [io.github.propactive](https:\/\/plugins.gradle.org\/plugin\/io.github.propactive)\n * Maven Central: [io.github.propactive:propactive-jvm](https:\/\/search.maven.org\/artifact\/io.github.propactive\/propactive-jvm)"}'
   Update-Readme:
     needs: Prepare-Release
     runs-on: ubuntu-22.04

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
       - name: 'Set up JDK 17'
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
### Changes
- Use a scope-restricted (bot) account to bypass branch protection limitations as GH actions do not provide a way to bypass protected branches for workflow automations  
- Improve automated release notes draft
- Remove access-token configuration for remote URL for tag release as it relies on SSH deploy key.

**Please see the following for reference:**
- GH actions branch protection limitations: https://github.com/community/community/discussions/13836
- Release API endpoint: https://docs.github.com/en/rest/releases/releases#create-a-release
- Escaping release body: https://www.freeformatter.com/json-escape.html#before-output