### PR TITLE
#55 add logging support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,8 @@ subprojects {
     apply(plugin = rootProject.libs.plugins.gradle.ktlint.get().pluginId)
 
     dependencies {
+        implementation(rootProject.libs.log4j.api.kotlin)
+        testImplementation(rootProject.libs.log4j.core)
         testImplementation(rootProject.libs.mockk)
         testImplementation(rootProject.libs.junit.jupiter)
         testImplementation(rootProject.libs.kotest.assertions.core)

--- a/propactive-jvm/build.gradle.kts
+++ b/propactive-jvm/build.gradle.kts
@@ -8,6 +8,7 @@ val isVersionedSnapshot = isSemVersioned && "$version".endsWith("-SNAPSHOT")
 val isVersionedRelease = isSemVersioned && isVersionedSnapshot.not()
 
 dependencies {
+    api(project(":propactive-logging"))
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlin.reflect)
     implementation(libs.kotlin.stdlib)

--- a/propactive-jvm/src/main/kotlin/io/github/propactive/entry/EntryFactory.kt
+++ b/propactive-jvm/src/main/kotlin/io/github/propactive/entry/EntryFactory.kt
@@ -3,15 +3,17 @@ package io.github.propactive.entry
 import io.github.propactive.config.KEY_VALUE_DELIMITER
 import io.github.propactive.config.UNSPECIFIED_ENVIRONMENT
 import io.github.propactive.entry.EntryFailureReason.MISSING_KEY_VALUE_DELIMITER_FOR_A_MULTI_ENTRIES
+import io.github.propactive.logging.PropactiveLogger.trace
 
 object EntryFactory {
     @JvmStatic
     fun create(entries: Array<String>) = entries
+        .trace { "Expanding Entries: " + toList() }
         .apply {
             if (size > 1) onEach { entry ->
                 require(
                     entry.count { it == KEY_VALUE_DELIMITER } > 0,
-                    MISSING_KEY_VALUE_DELIMITER_FOR_A_MULTI_ENTRIES(entry)
+                    MISSING_KEY_VALUE_DELIMITER_FOR_A_MULTI_ENTRIES(entry),
                 )
             }
         }

--- a/propactive-jvm/src/main/kotlin/io/github/propactive/environment/EnvironmentBuilder.kt
+++ b/propactive-jvm/src/main/kotlin/io/github/propactive/environment/EnvironmentBuilder.kt
@@ -6,6 +6,8 @@ import io.github.propactive.environment.EnvironmentFailureReason.ENVIRONMENT_FIL
 import io.github.propactive.environment.EnvironmentFailureReason.ENVIRONMENT_INVALID_FILENAME
 import io.github.propactive.environment.EnvironmentFailureReason.ENVIRONMENT_NAME_IS_NOT_SET
 import io.github.propactive.environment.EnvironmentFailureReason.ENVIRONMENT_PROPERTIES_IS_NOT_SET
+import io.github.propactive.logging.PropactiveLogger.debug
+import io.github.propactive.logging.PropactiveLogger.trace
 import io.github.propactive.property.PropertyModel
 import kotlin.text.RegexOption.MULTILINE
 
@@ -25,19 +27,23 @@ class EnvironmentBuilder private constructor() : Builder<EnvironmentModel> {
         internal fun environmentBuilder() = EnvironmentBuilder()
     }
 
-    override fun build(): EnvironmentModel = apply {
-        check(::name.isInitialized, ENVIRONMENT_NAME_IS_NOT_SET)
-        check(::filename.isInitialized, ENVIRONMENT_FILENAME_IS_NOT_SET(name))
-        check(::properties.isInitialized, ENVIRONMENT_PROPERTIES_IS_NOT_SET(name))
-    }.run {
-        EnvironmentModel(
-            name,
-            filename
-                .replace(EXPANSION_WILDCARD, name)
-                .apply { require(matches(GLOBALLY_VALID_FILENAME), ENVIRONMENT_INVALID_FILENAME(name, this)) },
-            properties
-                .filter { name == it.environment }
-                .toSet(),
-        )
-    }
+    override fun build(): EnvironmentModel = this
+        .apply {
+            check(::name.isInitialized, ENVIRONMENT_NAME_IS_NOT_SET)
+            check(::filename.isInitialized, ENVIRONMENT_FILENAME_IS_NOT_SET(name))
+            check(::properties.isInitialized, ENVIRONMENT_PROPERTIES_IS_NOT_SET(name))
+        }
+        .debug { "Building environment: $name ($filename)" }
+        .run {
+            EnvironmentModel(
+                name,
+                filename
+                    .replace(EXPANSION_WILDCARD, name)
+                    .apply { require(matches(GLOBALLY_VALID_FILENAME), ENVIRONMENT_INVALID_FILENAME(name, this)) },
+                properties
+                    .filter { name == it.environment }
+                    .toSet(),
+            )
+        }
+        .trace { "Built environment: $this" }
 }

--- a/propactive-jvm/src/main/kotlin/io/github/propactive/environment/EnvironmentFactory.kt
+++ b/propactive-jvm/src/main/kotlin/io/github/propactive/environment/EnvironmentFactory.kt
@@ -34,7 +34,7 @@ object EnvironmentFactory {
             }
         }
         .toSet()
-        .info { "Done - Number of Environments: $size" }
+        .debug { "Done - Number of Environments: $size" }
 
     private fun List<EntryModel>.expandIfMultipleKeysPerEntry() = this.flatMap { entry ->
         entry.key

--- a/propactive-jvm/src/main/kotlin/io/github/propactive/environment/EnvironmentFactory.kt
+++ b/propactive-jvm/src/main/kotlin/io/github/propactive/environment/EnvironmentFactory.kt
@@ -7,29 +7,34 @@ import io.github.propactive.entry.EntryModel
 import io.github.propactive.environment.EnvironmentBuilder.Companion.environmentBuilder
 import io.github.propactive.environment.EnvironmentFailureReason.ENVIRONMENT_INVALID_KEY_EXPANSION
 import io.github.propactive.environment.EnvironmentFailureReason.ENVIRONMENT_MISSING_ANNOTATION
+import io.github.propactive.logging.PropactiveLogger.debug
+import io.github.propactive.logging.PropactiveLogger.info
 import io.github.propactive.property.PropertyFactory
 import kotlin.reflect.KClass
 import kotlin.reflect.full.findAnnotation
 
 object EnvironmentFactory {
     @JvmStatic
-    fun create(clazz: KClass<out Any>) =
-        requireNotNull(clazz.findAnnotation<Environment>(), ENVIRONMENT_MISSING_ANNOTATION)
-            .value
-            .run(EntryFactory::create)
-            .expandIfMultipleKeysPerEntry()
-            .let { entries ->
-                with(PropertyFactory.create(clazz.members)) {
-                    entries.map { (environment, filename) ->
-                        environmentBuilder()
-                            .withName(environment)
-                            .withFilename(filename)
-                            .withProperties(this)
-                            .build()
-                    }
+    fun create(clazz: KClass<out Any>): Set<EnvironmentModel> = clazz
+        .info { "Constructing Environments..." }
+        .debug { "With annotations: $annotations" }
+        .run { requireNotNull(findAnnotation<Environment>(), ENVIRONMENT_MISSING_ANNOTATION) }
+        .value
+        .run(EntryFactory::create)
+        .expandIfMultipleKeysPerEntry()
+        .let { entries ->
+            with(PropertyFactory.create(clazz.members)) {
+                entries.map { (environment, filename) ->
+                    environmentBuilder()
+                        .withName(environment)
+                        .withFilename(filename)
+                        .withProperties(this)
+                        .build()
                 }
             }
-            .toSet()
+        }
+        .toSet()
+        .info { "Done - Number of Environments: $size" }
 
     private fun List<EntryModel>.expandIfMultipleKeysPerEntry() = this.flatMap { entry ->
         entry.key

--- a/propactive-jvm/src/main/kotlin/io/github/propactive/property/PropertyFactory.kt
+++ b/propactive-jvm/src/main/kotlin/io/github/propactive/property/PropertyFactory.kt
@@ -3,6 +3,9 @@ package io.github.propactive.property
 import io.github.propactive.config.MULTIPLE_ENVIRONMENT_DELIMITER
 import io.github.propactive.config.UNSPECIFIED_ENVIRONMENT
 import io.github.propactive.entry.EntryFactory
+import io.github.propactive.logging.PropactiveLogger.debug
+import io.github.propactive.logging.PropactiveLogger.info
+import io.github.propactive.logging.PropactiveLogger.trace
 import io.github.propactive.property.PropertyFailureReason.PROPERTY_FIELD_HAS_INVALID_TYPE
 import io.github.propactive.property.PropertyFailureReason.PROPERTY_FIELD_INACCESSIBLE
 import kotlin.reflect.KCallable
@@ -15,7 +18,10 @@ import kotlin.reflect.full.isSubtypeOf
 internal object PropertyFactory {
     @JvmStatic
     fun create(kCallables: Collection<KCallable<*>>) = kCallables
+        .info { "Constructing Properties..." }
+        .trace { "With KCallables: $this" }
         .mapNotNull { it.findAnnotation<Property>()?.run { it to this } }
+        .debug { "With Properties: $this" }
         .flatMap { (k, property) ->
             check(k.visibility != PRIVATE, PROPERTY_FIELD_INACCESSIBLE(k.name))
             check(k.returnType.isSubtypeOf(String::class.createType()), PROPERTY_FIELD_HAS_INVALID_TYPE(k.name))
@@ -37,6 +43,7 @@ internal object PropertyFactory {
                         }
                 }
         }
+        .info { "Done - Total Number of Property Permutations: $size" }
 
     private fun String.expandIfMultipleKeysPerEntry(): List<String> = this
         .split(MULTIPLE_ENVIRONMENT_DELIMITER)

--- a/propactive-jvm/src/test/kotlin/io/github/propactive/environment/EnvironmentFactoryTest.kt
+++ b/propactive-jvm/src/test/kotlin/io/github/propactive/environment/EnvironmentFactoryTest.kt
@@ -85,6 +85,26 @@ internal class EnvironmentFactoryTest {
                     )
                 }
         }
+        @Test
+        fun `given WithDifferentEnvironmentValuesAndMultipleProperties, when factory creates a DAO, then it should do the correct value associations`() {
+            EnvironmentFactory
+                .create(WithDifferentEnvironmentValuesAndMultipleProperties::class)
+                .apply {
+                    this shouldHaveSize 2
+                    this.toList().forEachIndexed { index, environment ->
+                        environment.shouldMatch {
+                            withName("env$index")
+                            withFilename("env$index-application.properties")
+                            withProperties(
+                                propertyMatcher()
+                                    .withName("test.resource.property${index + 1}")
+                                    .withEnvironment("env$index")
+                                    .withValue("property${index + 1}Value"),
+                            )
+                        }
+                    }
+                }
+        }
 
         @Test
         fun `given WithEnvironmentKeyExpansion, when factory creates a DAO, then it should correctly expand key values`() {
@@ -142,6 +162,15 @@ internal class EnvironmentFactoryTest {
         const val property1 = "test.resource.property1"
 
         @Property(["property2Value"])
+        const val property2 = "test.resource.property2"
+    }
+
+    @Environment(["env0: env0-application.properties", "env1: env1-application.properties"])
+    object WithDifferentEnvironmentValuesAndMultipleProperties {
+        @Property(["env0: property1Value"])
+        const val property1 = "test.resource.property1"
+
+        @Property(["env1: property2Value"])
         const val property2 = "test.resource.property2"
     }
 

--- a/propactive-jvm/src/test/resources/log4j2-test.xml
+++ b/propactive-jvm/src/test/resources/log4j2-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" strict="true" name="Log4jXMLConfigForTests">
+    <Properties>
+        <Property name="CONSOLE_LOG_PATTERN">%m %ex%n</Property>
+    </Properties>
+    <Appenders>
+        <Appender type="Console" name="consoleAppender" target="SYSTEM_OUT">
+            <Layout type="PatternLayout" pattern="${CONSOLE_LOG_PATTERN}"/>
+        </Appender>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="consoleAppender"/>
+        </Root>
+        <Logger name="Propactive" level="TRACE" additivity="false">
+            <AppenderRef ref="consoleAppender"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/propactive-logging/build.gradle.kts
+++ b/propactive-logging/build.gradle.kts
@@ -1,0 +1,6 @@
+val isDevVersion = "$version" == "DEV-SNAPSHOT"
+val isSemVersioned = "$version".matches(Regex("[0-9]+\\.[0-9]+\\.[0-9]+.*?"))
+val isVersionedSnapshot = isSemVersioned && "$version".endsWith("-SNAPSHOT")
+val isVersionedRelease = isSemVersioned && isVersionedSnapshot.not()
+
+dependencies { implementation(libs.kotlin.reflect) }

--- a/propactive-logging/src/main/kotlin/io/github/propactive/logging/Color.kt
+++ b/propactive-logging/src/main/kotlin/io/github/propactive/logging/Color.kt
@@ -1,0 +1,7 @@
+package io.github.propactive.logging
+
+internal object Color {
+    @JvmStatic internal fun blue(text: String) = "\u001b[0;34m$text\u001b[m"
+    @JvmStatic internal fun magenta(text: String) = "\u001b[0;35m$text\u001b[m"
+    @JvmStatic internal fun cyan(text: String) = "\u001b[0;36m$text\u001b[m"
+}

--- a/propactive-logging/src/main/kotlin/io/github/propactive/logging/PropactiveLogger.kt
+++ b/propactive-logging/src/main/kotlin/io/github/propactive/logging/PropactiveLogger.kt
@@ -1,0 +1,29 @@
+package io.github.propactive.logging
+
+import org.apache.logging.log4j.kotlin.logger
+
+object PropactiveLogger {
+    internal const val NAME = "Propactive"
+    private val DELEGATE = logger(NAME)
+
+    @JvmStatic
+    fun <T : Any> T.info(supplier: T.() -> String): T = this.apply {
+        DELEGATE.info {
+            "${Color.magenta("info  ->")} ${supplier.invoke(this)}"
+        }
+    }
+
+    @JvmStatic
+    fun <T : Any> T.debug(supplier: T.() -> String): T = this.apply {
+        DELEGATE.debug {
+            "${Color.blue("debug ->")} ${supplier.invoke(this)}"
+        }
+    }
+
+    @JvmStatic
+    fun <T : Any> T.trace(supplier: T.() -> String): T = this.apply {
+        DELEGATE.trace {
+            "${Color.cyan("trace ->")} ${supplier.invoke(this)}"
+        }
+    }
+}

--- a/propactive-logging/src/main/kotlin/io/github/propactive/logging/PropactiveLogger.kt
+++ b/propactive-logging/src/main/kotlin/io/github/propactive/logging/PropactiveLogger.kt
@@ -8,22 +8,16 @@ object PropactiveLogger {
 
     @JvmStatic
     fun <T : Any> T.info(supplier: T.() -> String): T = this.apply {
-        DELEGATE.info {
-            "${Color.magenta("info  ->")} ${supplier.invoke(this)}"
-        }
+        DELEGATE.info { Color.magenta(supplier.invoke(this)) }
     }
 
     @JvmStatic
     fun <T : Any> T.debug(supplier: T.() -> String): T = this.apply {
-        DELEGATE.debug {
-            "${Color.blue("debug ->")} ${supplier.invoke(this)}"
-        }
+        DELEGATE.debug { Color.blue(supplier.invoke(this)) }
     }
 
     @JvmStatic
     fun <T : Any> T.trace(supplier: T.() -> String): T = this.apply {
-        DELEGATE.trace {
-            "${Color.cyan("trace ->")} ${supplier.invoke(this)}"
-        }
+        DELEGATE.trace { Color.cyan(supplier.invoke(this)) }
     }
 }

--- a/propactive-logging/src/test/kotlin/io/github/propactive/logging/LoggerTest.kt
+++ b/propactive-logging/src/test/kotlin/io/github/propactive/logging/LoggerTest.kt
@@ -87,35 +87,35 @@ class LoggerTest {
     }
 
     @Test
-    fun shouldHighlightInfoPrefixWithMagentaColor() {
+    fun shouldHighlightInfoWithMagentaColor() {
         info {
             "..."
         }
 
         infoCollector
             .logs().single()
-            .shouldStartWith(Color.magenta("info  ->"))
+            .shouldStartWith(Color.magenta("..."))
     }
 
     @Test
-    fun shouldHighlightDebugPrefixWithBlueColor() {
+    fun shouldHighlightDebugWithBlueColor() {
         debug {
             "..."
         }
 
         debugCollector
             .logs().single()
-            .shouldStartWith(Color.blue("debug ->"))
+            .shouldStartWith(Color.blue("..."))
     }
 
     @Test
-    fun shouldHighlightTracePrefixWithCyanColor() {
+    fun shouldHighlightTraceWithCyanColor() {
         trace {
             "..."
         }
 
         traceCollector
             .logs().single()
-            .shouldStartWith(Color.cyan("trace ->"))
+            .shouldStartWith(Color.cyan("..."))
     }
 }

--- a/propactive-logging/src/test/kotlin/io/github/propactive/logging/LoggerTest.kt
+++ b/propactive-logging/src/test/kotlin/io/github/propactive/logging/LoggerTest.kt
@@ -1,0 +1,121 @@
+package io.github.propactive.logging
+
+import io.github.propactive.logging.PropactiveLogger.info
+import io.github.propactive.logging.PropactiveLogger.debug
+import io.github.propactive.logging.PropactiveLogger.trace
+import io.github.propactive.logging.utils.LogsCollector
+import io.github.propactive.logging.utils.LogsCollectorExtension
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.string.shouldStartWith
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.core.Logger
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(LogsCollectorExtension::class)
+class LoggerTest {
+    private val infoCollector = LogsCollector(LogManager.getLogger(PropactiveLogger.NAME) as Logger, Level.INFO)
+    private val debugCollector = LogsCollector(LogManager.getLogger(PropactiveLogger.NAME) as Logger, Level.DEBUG)
+    private val traceCollector = LogsCollector(LogManager.getLogger(PropactiveLogger.NAME) as Logger, Level.TRACE)
+
+    @Test
+    fun shouldLogInfoLogsToCorrectLevel() {
+        info {
+            "..."
+        }
+
+        infoCollector.logs() shouldHaveSize 1
+        debugCollector.logs() shouldHaveSize 1
+        traceCollector.logs() shouldHaveSize 1
+    }
+
+    @Test
+    fun shouldLogDebugLogsToCorrectLevel() {
+        debug {
+            "..."
+        }
+
+        infoCollector.logs() shouldHaveSize 0
+        debugCollector.logs() shouldHaveSize 1
+        traceCollector.logs() shouldHaveSize 1
+    }
+
+    @Test
+    fun shouldLogTraceLogsToCorrectLevel() {
+        trace {
+            "..."
+        }
+
+        infoCollector.logs() shouldHaveSize 0
+        debugCollector.logs() shouldHaveSize 0
+        traceCollector.logs() shouldHaveSize 1
+    }
+
+    @Test
+    fun shouldPreserveOriginalInfoMessage() {
+        info {
+            "A Logged Info Message"
+        }
+
+        infoCollector
+            .find { it.contains("A Logged Info Message") }
+            .shouldNotBeNull()
+    }
+
+    @Test
+    fun shouldPreserveOriginalDebugMessage() {
+        debug {
+            "A Logged Debug Message"
+        }
+
+        debugCollector
+            .find { it.contains("A Logged Debug Message") }
+            .shouldNotBeNull()
+    }
+
+    @Test
+    fun shouldPreserveOriginalTraceMessage() {
+        trace {
+            "A Logged Trace Message"
+        }
+
+        traceCollector
+            .find { it.contains("A Logged Trace Message") }
+            .shouldNotBeNull()
+    }
+
+    @Test
+    fun shouldHighlightInfoPrefixWithMagentaColor() {
+        info {
+            "..."
+        }
+
+        infoCollector
+            .logs().single()
+            .shouldStartWith(Color.magenta("info  ->"))
+    }
+
+    @Test
+    fun shouldHighlightDebugPrefixWithBlueColor() {
+        debug {
+            "..."
+        }
+
+        debugCollector
+            .logs().single()
+            .shouldStartWith(Color.blue("debug ->"))
+    }
+
+    @Test
+    fun shouldHighlightTracePrefixWithCyanColor() {
+        trace {
+            "..."
+        }
+
+        traceCollector
+            .logs().single()
+            .shouldStartWith(Color.cyan("trace ->"))
+    }
+}

--- a/propactive-logging/src/test/kotlin/io/github/propactive/logging/utils/InMemoryAppender.kt
+++ b/propactive-logging/src/test/kotlin/io/github/propactive/logging/utils/InMemoryAppender.kt
@@ -1,0 +1,44 @@
+package io.github.propactive.logging.utils
+
+import java.io.Serializable
+import java.util.UUID
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.core.Appender
+import org.apache.logging.log4j.core.Filter
+import org.apache.logging.log4j.core.Layout
+import org.apache.logging.log4j.core.LogEvent
+import org.apache.logging.log4j.core.appender.AbstractAppender
+import org.apache.logging.log4j.core.config.Property
+
+/**
+ * An [Appender] that stores all the log events in memory.
+ * This is useful for testing purposes.
+ */
+class InMemoryAppender(
+    private val requiredLayout: Layout<out Serializable>,
+    private val requiredLevel: Level,
+) : AbstractAppender(
+    InMemoryAppender::class.simpleName.plus("-${UUID.randomUUID()}"),
+    NO_FILTER,
+    requiredLayout,
+    IGNORE_EXCEPTIONS,
+    EMPTY_PROPERTIES,
+) {
+    private val events: MutableList<String> = ArrayList()
+
+    internal fun events() = events.toList()
+
+    override fun append(event: LogEvent) {
+        this.requiredLayout
+            .toByteArray(event.toImmutable())
+            .let { msg -> String(msg).trim() + "\n" }
+            .takeIf { event.level.isMoreSpecificThan(requiredLevel) }
+            ?.let(events::add)
+    }
+
+    companion object {
+        private val NO_FILTER: Filter? = null
+        private const val IGNORE_EXCEPTIONS = false
+        private val EMPTY_PROPERTIES = emptyArray<Property>()
+    }
+}

--- a/propactive-logging/src/test/kotlin/io/github/propactive/logging/utils/LogsCollector.kt
+++ b/propactive-logging/src/test/kotlin/io/github/propactive/logging/utils/LogsCollector.kt
@@ -1,0 +1,46 @@
+package io.github.propactive.logging.utils
+
+import org.apache.logging.log4j.Level
+import org.apache.logging.log4j.core.Appender
+import org.apache.logging.log4j.core.Logger
+import org.apache.logging.log4j.core.appender.ConsoleAppender
+
+/**
+ * A utility class that collects all the logs of a given logger.
+ * This is useful for testing purposes.
+ */
+class LogsCollector(
+    private val logger: Logger,
+    private val requiredLevel: Level = Level.INFO
+) {
+    private val originalLevel = logger.level
+    private val originalLayout = findConsoleAppender(logger).layout
+    private lateinit var inMemoryAppender: InMemoryAppender
+
+    internal fun start() {
+        inMemoryAppender = InMemoryAppender(originalLayout, requiredLevel)
+            .also(InMemoryAppender::start)
+            .also(logger::addAppender)
+            .apply { logger.level = requiredLevel }
+    }
+
+    internal fun stop() {
+        inMemoryAppender
+            .also(InMemoryAppender::stop)
+            .also(logger::removeAppender)
+            .apply { logger.level = originalLevel }
+    }
+
+    fun logs() = inMemoryAppender.events()
+
+    fun find(predicate: (String) -> Boolean) = logs().find(predicate)
+
+    private tailrec fun findConsoleAppender(logger: Logger): Appender {
+        if (logger.appenders.isEmpty() && logger.isAdditive.not())
+            error("Cannot find a ConsoleAppender for logger ${logger.name}")
+        else return logger
+            .appenders.values
+            .find { it is ConsoleAppender }
+            ?: findConsoleAppender(logger.parent)
+    }
+}

--- a/propactive-logging/src/test/kotlin/io/github/propactive/logging/utils/LogsCollectorExtension.kt
+++ b/propactive-logging/src/test/kotlin/io/github/propactive/logging/utils/LogsCollectorExtension.kt
@@ -1,0 +1,37 @@
+package io.github.propactive.logging.utils
+
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback
+import org.junit.jupiter.api.extension.BeforeTestExecutionCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.TestInstancePostProcessor
+import kotlin.reflect.full.createType
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+
+/**
+ * A handy extension that starts and stops all [LogsCollector]s in a test class.
+ *
+ * It is required to annotate the test class with [org.junit.jupiter.api.extension.ExtendWith].
+ * The extension will find all [LogsCollector]s in the test class and start them before each test.
+ * After each test, the extension will stop all [LogsCollector]s.
+ */
+class LogsCollectorExtension : BeforeTestExecutionCallback, AfterTestExecutionCallback, TestInstancePostProcessor {
+    private var collectors: List<LogsCollector> = emptyList()
+
+    @Throws(Exception::class)
+    override fun postProcessTestInstance(testInstance: Any, context: ExtensionContext) {
+        collectors = testInstance::class.memberProperties.asSequence()
+            .filter { it.returnType == LogsCollector::class.createType() }
+            .onEach { it.isAccessible = true }
+            .map { it.getter.call(testInstance) as LogsCollector }
+            .toList()
+    }
+
+    @Throws(Exception::class)
+    override fun beforeTestExecution(context: ExtensionContext) =
+        collectors.forEach(LogsCollector::start)
+
+    @Throws(Exception::class)
+    override fun afterTestExecution(context: ExtensionContext) =
+        collectors.forEach(LogsCollector::stop)
+}

--- a/propactive-logging/src/test/resources/log4j2-test.xml
+++ b/propactive-logging/src/test/resources/log4j2-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" strict="true" name="Log4jXMLConfigForTests">
+    <Properties>
+        <Property name="CONSOLE_LOG_PATTERN">%m %ex%n</Property>
+    </Properties>
+    <Appenders>
+        <Appender type="Console" name="consoleAppender" target="SYSTEM_OUT">
+            <Layout type="PatternLayout" pattern="${CONSOLE_LOG_PATTERN}"/>
+        </Appender>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO" additivity="true">
+            <AppenderRef ref="consoleAppender"/>
+        </Root>
+        <Logger name="Propactive" level="TRACE" additivity="false">
+            <AppenderRef ref="consoleAppender"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/propactive-plugin/build.gradle.kts
+++ b/propactive-plugin/build.gradle.kts
@@ -28,6 +28,7 @@ pluginBundle {
 
 dependencies {
     api(project(":propactive-jvm"))
+    api(project(":propactive-logging"))
 
     implementation(gradleApi())
     testImplementation(gradleTestKit())

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/plugin/Configuration.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/plugin/Configuration.kt
@@ -22,8 +22,17 @@ open class Configuration(
         internal const val DEFAULT_ENVIRONMENTS = "*"
         internal const val DEFAULT_IMPLEMENTATION_CLASS = "ApplicationProperties"
         internal const val DEFAULT_BUILD_DESTINATION = "properties"
+
         // NOTE: Gradle plugin extension values cannot be null if you want to register them as property values
         internal const val DEFAULT_FILENAME_OVERRIDE = ""
         internal const val DEFAULT_CLASS_COMPILE_DEPENDENCY = "jar"
     }
+
+    override fun toString(): String = "Configuration(" +
+        "environments=$environments, " +
+        "implementationClass=$implementationClass, " +
+        "destination=$destination, " +
+        "filenameOverride=$filenameOverride, " +
+        "classCompileDependency=$classCompileDependency" +
+        ")"
 }

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/plugin/Propactive.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/plugin/Propactive.kt
@@ -1,5 +1,7 @@
 package io.github.propactive.plugin
 
+import io.github.propactive.logging.PropactiveLogger.debug
+import io.github.propactive.logging.PropactiveLogger.trace
 import io.github.propactive.task.GenerateApplicationPropertiesTask
 import io.github.propactive.task.ValidateApplicationPropertiesTask
 import org.gradle.api.Plugin
@@ -9,10 +11,12 @@ open class Propactive : Plugin<Project> {
     override fun apply(target: Project) {
         target
             .extensions
+            .debug { "Creating extension: ${Configuration::class.simpleName}" }
             .create(PROPACTIVE_GROUP, Configuration::class.java)
 
         target
             .tasks
+            .debug { "Registering Task: ${GenerateApplicationPropertiesTask.TASK_NAME}" }
             .register(
                 GenerateApplicationPropertiesTask.TASK_NAME,
                 GenerateApplicationPropertiesTask::class.java,
@@ -20,6 +24,7 @@ open class Propactive : Plugin<Project> {
 
         target
             .tasks
+            .debug { "Registering Task: ${ValidateApplicationPropertiesTask.TASK_NAME}" }
             .register(
                 ValidateApplicationPropertiesTask.TASK_NAME,
                 ValidateApplicationPropertiesTask::class.java,
@@ -54,7 +59,11 @@ open class Propactive : Plugin<Project> {
     companion object {
         internal val PROPACTIVE_GROUP = Propactive::class.simpleName!!.lowercase()
 
-        private fun Project.propertyOrDefault(propertyName: String, default: String) =
-            default.takeUnless { hasProperty(propertyName) } ?: "${property(propertyName)}"
+        private fun Project.propertyOrDefault(propertyName: String, default: String): String =
+            (
+                default
+                    .takeUnless { hasProperty(propertyName) } ?: "${property(propertyName)}"
+                )
+                .trace { "Set $propertyName to: $this" }
     }
 }

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/project/ImplementationClassFinder.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/project/ImplementationClassFinder.kt
@@ -1,6 +1,7 @@
 package io.github.propactive.project
 
 import io.github.propactive.environment.EnvironmentFactory
+import io.github.propactive.logging.PropactiveLogger.debug
 import io.github.propactive.plugin.Configuration
 import io.github.propactive.plugin.Configuration.Companion.DEFAULT_IMPLEMENTATION_CLASS
 import io.github.propactive.plugin.Configuration.Companion.DEFAULT_CLASS_COMPILE_DEPENDENCY
@@ -16,6 +17,7 @@ object ImplementationClassFinder {
         val configuration = project
             .extensions
             .findByType(Configuration::class.java)
+            ?.debug { "Found: $this" }
 
         val classCompileDependency = configuration
             ?.classCompileDependency
@@ -26,13 +28,16 @@ object ImplementationClassFinder {
             ?: DEFAULT_IMPLEMENTATION_CLASS
 
         return project
+            .debug { "Looking for implementation class \"$implementationClass\" using classes compiled from task: $classCompileDependency" }
             .getTasksByName(classCompileDependency, true)
+            .apply { require(isNotEmpty()) { "Couldn't find task: $classCompileDependency" } }
             .fold(setOf<File>()) { acc, task -> acc.plus(task.outputs.files.files) }
             .firstNotNullOfOrNull {
                 URLClassLoader
                     .newInstance(arrayOf(URL("jar:file:${it.path}!/")), EnvironmentFactory::class.java.classLoader)
                     .runCatching { loadClass(implementationClass).kotlin }
                     .getOrNull()
+                    ?.debug { "Found: $this" }
             } ?: error("Expected to find implementation class $implementationClass")
     }
 }

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/project/PropertiesFileWriter.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/project/PropertiesFileWriter.kt
@@ -1,6 +1,8 @@
 package io.github.propactive.project
 
 import io.github.propactive.environment.EnvironmentModel
+import io.github.propactive.logging.PropactiveLogger.debug
+import io.github.propactive.logging.PropactiveLogger.trace
 import java.io.File
 import java.nio.file.Path
 
@@ -16,11 +18,15 @@ object PropertiesFileWriter {
 
         File(Path.of(destination, filename).toUri())
             .apply { parentFile.mkdirs() }
+            .debug { "Writing properties to file location: $absolutePath" }
             .also { file ->
                 environment
+                    .debug { "For the following environment: ${ name.takeUnless(String::isBlank) ?: "(Unspecified Environment Name)"}" }
                     .properties
+                    .trace { "With the following properties: $this" }
                     .joinToString(separator = "\n") { "${it.name}=${it.value}" }
                     .apply(file::writeText)
+                    .trace { "Wrote the following properties to file:\n${file.readText()}" }
             }
     }
 }

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/task/GenerateApplicationProperties.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/task/GenerateApplicationProperties.kt
@@ -2,6 +2,7 @@ package io.github.propactive.task
 
 import io.github.propactive.environment.EnvironmentFactory
 import io.github.propactive.environment.EnvironmentModel
+import io.github.propactive.logging.PropactiveLogger.info
 import io.github.propactive.project.PropertiesFileWriter.writePropertiesFile
 import io.github.propactive.plugin.Configuration
 import io.github.propactive.plugin.Configuration.Companion.DEFAULT_ENVIRONMENTS
@@ -11,11 +12,13 @@ import org.gradle.api.Project
 object GenerateApplicationProperties {
     @JvmStatic
     internal fun invoke(project: Project) = project
+        .info { "Generating application properties..." }
         .let(ImplementationClassFinder::find)
         .let(EnvironmentFactory::create)
         .let { environmentModels ->
             with(project.extensions.findByType(Configuration::class.java)!!) {
                 environmentModels
+                    .info { "Found $size environment(s) to generate properties for..." }
                     .requireSingleEnvironmentWhenCustomFilenameIsGiven(environments, filenameOverride)
                     .filter { environments.contains(it.name) || environments.contains(DEFAULT_ENVIRONMENTS) }
                     .forEach { environment -> writePropertiesFile(environment, destination, filenameOverride) }

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/task/ValidateApplicationProperties.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/task/ValidateApplicationProperties.kt
@@ -1,6 +1,7 @@
 package io.github.propactive.task
 
 import io.github.propactive.environment.EnvironmentFactory
+import io.github.propactive.logging.PropactiveLogger.info
 import io.github.propactive.project.ImplementationClassFinder
 import org.gradle.api.Project
 
@@ -9,6 +10,7 @@ object ValidateApplicationProperties {
     internal fun invoke(
         project: Project
     ) = project
+        .info { "Validating application properties..." }
         .let(ImplementationClassFinder::find)
         .also(EnvironmentFactory::create)
 }

--- a/propactive-plugin/src/main/kotlin/io/github/propactive/task/validators/ConfigurationValidator.kt
+++ b/propactive-plugin/src/main/kotlin/io/github/propactive/task/validators/ConfigurationValidator.kt
@@ -1,5 +1,6 @@
 package io.github.propactive.task.validators
 
+import io.github.propactive.logging.PropactiveLogger.debug
 import io.github.propactive.plugin.Configuration
 
 object ConfigurationValidator {
@@ -13,6 +14,7 @@ object ConfigurationValidator {
 
         project
             .tasks
+            .debug { "Ensuring that the given class compile dependency Gradle task exists: $id" }
             .findByName(id)
             .let { requireNotNull(it) { "Given Gradle task for source class compile dependency was not found: $id" } }
             .name

--- a/propactive-plugin/src/test/kotlin/io/github/propactive/project/ImplementationClassFinderTest.kt
+++ b/propactive-plugin/src/test/kotlin/io/github/propactive/project/ImplementationClassFinderTest.kt
@@ -31,12 +31,12 @@ internal class ImplementationClassFinderTest {
 
         configuration = mockk(relaxed = true)
 
-        urlClassLoader = mockk() {
+        urlClassLoader = mockk {
             every { loadClass(any()) } returns WithEmptyEnvironment::class.java
             every { URLClassLoader.newInstance(any(), any()) } returns this
         }
 
-        project = mockk() {
+        project = mockk {
             val task = mockk<Task> { every { outputs.files.files } returns setOf(mockk(relaxed = true)) }
             every { extensions.findByType(Configuration::class.java) } returns configuration
             every { getTasksByName(any(), true) } returns setOf(task)

--- a/propactive-plugin/src/test/kotlin/io/github/propactive/project/PropertiesFileWriterTest.kt
+++ b/propactive-plugin/src/test/kotlin/io/github/propactive/project/PropertiesFileWriterTest.kt
@@ -42,7 +42,7 @@ internal class PropertiesFileWriterTest {
             val property2 = mockedProperty(2)
             val property3 = mockedProperty(3)
             val fileName = Random.alphaNumeric()
-            val environment = mockk<EnvironmentModel> {
+            val environment = mockk<EnvironmentModel>(relaxed = true) {
                 every { filename } returns fileName
                 every { properties } returns setOf(property1, property2, property3)
             }

--- a/propactive-plugin/src/test/resources/log4j2-test.xml
+++ b/propactive-plugin/src/test/resources/log4j2-test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" strict="true" name="Log4jXMLConfigForTests">
+    <Properties>
+        <Property name="CONSOLE_LOG_PATTERN">%m %ex%n</Property>
+    </Properties>
+    <Appenders>
+        <Appender type="Console" name="consoleAppender" target="SYSTEM_OUT">
+            <Layout type="PatternLayout" pattern="${CONSOLE_LOG_PATTERN}"/>
+        </Appender>
+    </Appenders>
+    <Loggers>
+        <Root level="INFO">
+            <AppenderRef ref="consoleAppender"/>
+        </Root>
+        <Logger name="Propactive" level="TRACE" additivity="false">
+            <AppenderRef ref="consoleAppender"/>
+        </Logger>
+    </Loggers>
+</Configuration>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
             val kotlinVersion = "1.8.0"
-            val dokkaVersion = "1.7.20"     // NOTE: This is tmp until a 1.8.0 is released (i.e. should be coupled with kotlinVersion)
+            val dokkaVersion = "1.7.20" // NOTE: This is tmp until a 1.8.0 is released (i.e. should be coupled with kotlinVersion)
             val serializationVersion = "1.4.1"
             val mockkVersion = "1.13.2"
             val kotestVersion = "5.5.4"
@@ -18,7 +18,7 @@ dependencyResolutionManagement {
             val publishVersion = "1.0.0"
             val equalsVersion = "3.10"
             val log4jKotlinVersion = "1.2.0" // TODO: Upgrade to 1.3.0 if my PR is merged
-            val log4jVersion = "2.17.0"      // TODO: Upgrade to 2.19.0 if my PR is merged
+            val log4jVersion = "2.19.0"
 
             library("kotlin-reflect", "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
             library("kotlin-stdlib", "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 include(
     ":propactive-plugin",
     ":propactive-jvm",
+    ":propactive-logging",
 )
 
 dependencyResolutionManagement {
@@ -8,8 +9,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
             val kotlinVersion = "1.8.0"
-            // NOTE: This is tmp until a 1.8.0 is released (i.e. should be coupled with kotlinVersion)
-            val dokkaVersion = "1.7.20"
+            val dokkaVersion = "1.7.20"     // NOTE: This is tmp until a 1.8.0 is released (i.e. should be coupled with kotlinVersion)
             val serializationVersion = "1.4.1"
             val mockkVersion = "1.13.2"
             val kotestVersion = "5.5.4"
@@ -17,6 +17,8 @@ dependencyResolutionManagement {
             val ktlintVersion = "11.0.0"
             val publishVersion = "1.0.0"
             val equalsVersion = "3.10"
+            val log4jKotlinVersion = "1.2.0" // TODO: Upgrade to 1.3.0 if my PR is merged
+            val log4jVersion = "2.17.0"      // TODO: Upgrade to 2.19.0 if my PR is merged
 
             library("kotlin-reflect", "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
             library("kotlin-stdlib", "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
@@ -26,6 +28,9 @@ dependencyResolutionManagement {
             library("kotest-assertions-core", "io.kotest:kotest-assertions-core:$kotestVersion")
             library("junit-jupiter", "org.junit.jupiter:junit-jupiter:$junitVersion")
             library("equalsverifier", "nl.jqno.equalsverifier:equalsverifier:$equalsVersion")
+
+            library("log4j-api-kotlin", "org.apache.logging.log4j:log4j-api-kotlin:$log4jKotlinVersion")
+            library("log4j-core", "org.apache.logging.log4j:log4j-core:$log4jVersion")
 
             plugin("jetbrains-kotlin-jvm", "org.jetbrains.kotlin.jvm").version(kotlinVersion)
             plugin("jetbrains-dokka", "org.jetbrains.dokka").version(dokkaVersion)


### PR DESCRIPTION
### Changes
- [x] Introduce Log4J2 API ([Kotlin version](https://logging.apache.org/log4j/kotlin/)) to Propactive Plugin and JVM modules.
- [x] Add appropriate configuration files and logging.
- [x] Use Log4J2 implementations when running tests as dependency.

### Details:
- A new shared module named *propactive-logging* has been created which contains the logic and tests for the logging utility.
- The logger used throughout the application is named "propactive"
- For now, it has been decided only info, debug, and trace log levels are needed. (Error will be derived from STDERR)
- Logging has been added throughout the JVM and plugin module.
- A Log4J2 implementation when running tests as dependency has been complete. (For now the log level is set to trace, see the `log4j2-test.xml` file for details)