### PR TITLE
#68 patch gradle publish plugin

### DIFF
--- a/propactive-plugin/build.gradle.kts
+++ b/propactive-plugin/build.gradle.kts
@@ -1,6 +1,5 @@
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
-    `java-gradle-plugin`
     alias(libs.plugins.gradle.publish)
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,7 @@ dependencyResolutionManagement {
             val kotestVersion = "5.5.4"
             val junitVersion = "5.8.2"
             val ktlintVersion = "11.0.0"
-            val publishVersion = "1.0.0"
+            val publishVersion = "1.1.0"
             val publishNexusVersion = "1.1.0"
             val equalsVersion = "3.10"
             val log4jKotlinVersion = "1.2.0" // TODO: Upgrade to 1.3.0 if my PR is merged


### PR DESCRIPTION
## Changes
- Upgrade `com.gradle.plugin-publish` to `1.1.0` to patch critical bug.
- Remove `java-gradle-plugin` as we are using `libs.plugins.gradle.publish` instead.

#### Upgrade details: 
> Version 1.1.0
> Created 11 November 2022.
>
> - Fix a bug in handling `tags`, when solely relying on `gradlePlugin` block for configuring plugin publication
> - Forbid bypassing the Maven Publish plugin for generating plugin publication metadata

This upgrade was also recommended by Gradle official [publish-plugin documentation](https://plugins.gradle.org/docs/publish-plugin):

> NOTE: If you are using version 1.0.X of the plugin, please update to at least version 1.1.0, which contains critical bug fixes.


 see [stackoverflow.com/a/75850252/5037430](https://stackoverflow.com/a/75850252/5037430) for further details

Resolves #68 