### PR TITLE
#70 Patch Gradle-Nexus' publish-plugin

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,7 +14,7 @@ dependencyResolutionManagement {
             val junitVersion = "5.8.2"
             val ktlintVersion = "11.0.0"
             val publishVersion = "1.1.0"
-            val publishNexusVersion = "1.1.0"
+            val publishNexusVersion = "1.3.0"
             val equalsVersion = "3.10"
             val log4jKotlinVersion = "1.2.0" // TODO: Upgrade to 1.3.0 if my PR is merged
             val log4jVersion = "2.19.0"


### PR DESCRIPTION
## Changes

Upgrade io.github.gradle-nexus.publish-plugin to 1.3.0 to patch Gradle 8 compatibility.

For further details, see: https://github.com/gradle-nexus/publish-plugin/issues/208

Resolves #70  