### PR TITLE
#70 disable gradle nexus' publish plugin

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -16,6 +16,8 @@ jobs:
     # See: https://github.com/actions/runner/issues/1413#issuecomment-1230408270
     secrets: inherit
   CD:
+    # TMP: #70 Disable CD until gradle-nexus/publish-plugin/issues/208 is fixed
+    if: false
     needs: [CI]
     uses: ./.github/workflows/cd-workflow.yml
     # This only works for organization and repository secrets

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -20,6 +20,17 @@ jobs:
         run: make test-acceptance-propactive-plugin
       - name: 'tests: propactive-plugin (integration)'
         run: make test-integration-propactive-plugin
+      # TMP: #70 This should be removed once gradle-nexus/publish-plugin/issues/208 is fixed
+      - name: 'A timebomb to address #70 on the 01/05/2023'
+        run: |
+          if [[ $(date +%s) -gt 1682895600 ]]; then
+            echo "It has been 1 month since #70 was opened."
+            echo "Please check if gradle-nexus/publish-plugin/issues/208 has been fixed."
+            echo "  If it has, please update the plugin and re-enable the CD workflow."
+            echo "  else, please increase this timebomb by 1 month."
+            echo "See: propactive/propactive/issues/70"
+            exit 1
+          fi
       - name: 'Uploading test artifacts'
         if: success() || failure()
         uses: actions/upload-artifact@v3

--- a/propactive-jvm/build.gradle.kts
+++ b/propactive-jvm/build.gradle.kts
@@ -84,10 +84,4 @@ tasks {
     publish {
         onlyIf { isVersionedRelease || isVersionedSnapshot }
     }
-
-    // TMP #70: This is a workaround for an ongoing issue with: `publishJavaPublicationToSonatypeRepository`
-    //      It seems that the task is not correctly configured to run after the `sign` task, so the signature
-    //      is not included in the published artifact. Once a fix is released, this workaround can be removed.
-    //      See: https://github.com/gradle-nexus/publish-plugin/issues/208
-    withType<PublishToMavenRepository>().configureEach { mustRunAfter(withType<Sign>()) }
 }


### PR DESCRIPTION
### #70 - Changes
- Add a timebomb as a reminder to address gradle-nexus/publish-plugin/issues/208 in the future.
- Disable CD until gradle-nexus/publish-plugin/issues/208 is fixed.
- Revert temporary fix for Gradle-Nexus plugin.