### PR TITLE
#65 [U-ways] Fully containerise the development environment

### DIFF
--- a/.github/workflows/MANUAL-DEPLOYMENT.yml
+++ b/.github/workflows/MANUAL-DEPLOYMENT.yml
@@ -37,12 +37,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: 'Set up JDK 17'
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: liberica
-          cache: gradle
       - name: 'Importing GPG key'
         uses: crazy-max/ghaction-import-gpg@v5
         with:

--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -19,12 +19,6 @@ jobs:
     steps:
       - name: 'Checkout to current branch'
         uses: actions/checkout@v3
-      - name: 'Set up JDK 17'
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: liberica
-          cache: gradle
       - name: 'Importing GPG key'
         uses: crazy-max/ghaction-import-gpg@v5
         with:
@@ -55,12 +49,6 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-      - name: 'Set up JDK 17'
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: liberica
-          cache: gradle
       - name: 'Importing GPG key'
         uses: crazy-max/ghaction-import-gpg@v5
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -8,12 +8,6 @@ jobs:
     steps:
       - name: 'Checkout to current branch'
         uses: actions/checkout@v3
-      - name: 'Setup Gradle caching'
-        uses: actions/cache@v3
-        with:
-          path: $HOME/.gradle
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: ${{ runner.os }}-gradle-
       - name: 'tests: propactive-jvm'
         run: make test-propactive-jvm
       - name: 'tests: propactive-plugin (acceptance)'

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -8,12 +8,6 @@ jobs:
     steps:
       - name: 'Checkout to current branch'
         uses: actions/checkout@v3
-      - name: 'Set up JDK 17'
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: liberica
-          cache: gradle
       - name: 'tests: propactive-jvm'
         run: make test-propactive-jvm
       - name: 'tests: propactive-plugin (acceptance)'

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -8,30 +8,6 @@ jobs:
     steps:
       - name: 'Checkout to current branch'
         uses: actions/checkout@v3
-      # Next steps:
-      # 1. Create a directory for the gradle cache
-      # 2. Test it inside the docker container by trying to create a file in the cache directory
-      - name: 'Sandbox'
-        run: |
-          echo "---------------------------- For each user check their uid and gid"
-          id
-          echo "---------------------------- Checking $HOME ownerships"
-          ls -la $HOME
-          echo "---------------------------- Checking $GITHUB_WORKSPACE"
-          ls -la $GITHUB_WORKSPACE
-          echo "---------------------------- Creating $HOME/.gradle/test"
-          mkdir -p $HOME/.gradle/test
-
-          echo "---------------------------- For each user check their uid and gid (Docker)"
-          make run-cmd-inside-toolchain-runner CMD="id"
-          echo "---------------------------- Changing "gradle" user uid and gid to match host user"
-          make run-cmd-inside-toolchain-runner CMD="usermod -u 1001 gradle; groupmod -g 127 gradle; id gradle"
-          echo "---------------------------- Checking /home ownerships (Docker)"
-          make run-cmd-inside-toolchain-runner CMD="ls -la /home"
-          echo "---------------------------- Checking Propactive workspace (Docker)"
-          make run-cmd-inside-toolchain-runner CMD="ls -la /home/gradle/propactive"
-          echo "---------------------------- Creating /home/.gradle/test (Docker)"
-          make run-cmd-inside-toolchain-runner CMD="mkdir -p /home/.gradle/test"
       - name: 'Setup Gradle caching'
         uses: actions/cache@v3
         with:
@@ -45,9 +21,9 @@ jobs:
       - name: 'tests: propactive-plugin (integration)'
         run: make test-integration-propactive-plugin
       # TMP: #70 This should be removed once gradle-nexus/publish-plugin/issues/208 is fixed
-      - name: 'A timebomb to address #70 on the 01/05/2023'
+      - name: 'A timebomb to address #70 on the 01/10/2023'
         run: |
-          if [[ $(date +%s) -gt 1682895600 ]]; then
+          if [[ $(date +%s) -gt 1696114800 ]]; then
             echo "It has been 1 month since #70 was opened."
             echo "Please check if gradle-nexus/publish-plugin/issues/208 has been fixed."
             echo "  If it has, please update the plugin and re-enable the CD workflow."

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -8,6 +8,36 @@ jobs:
     steps:
       - name: 'Checkout to current branch'
         uses: actions/checkout@v3
+      # Next steps:
+      # 1. Create a directory for the gradle cache
+      # 2. Test it inside the docker container by trying to create a file in the cache directory
+      - name: 'Sandbox'
+        run: |
+          echo "---------------------------- For each user check their uid and gid"
+          id
+          echo "---------------------------- Checking $HOME ownerships"
+          ls -la $HOME
+          echo "---------------------------- Checking $GITHUB_WORKSPACE"
+          ls -la $GITHUB_WORKSPACE
+          echo "---------------------------- Creating $HOME/.gradle/test"
+          mkdir -p $HOME/.gradle/test
+
+          echo "---------------------------- For each user check their uid and gid (Docker)"
+          make run-cmd-inside-toolchain-runner CMD="id"
+          echo "---------------------------- Changing "gradle" user uid and gid to match host user"
+          make run-cmd-inside-toolchain-runner CMD="usermod -u 1001 gradle; groupmod -g 127 gradle; id gradle"
+          echo "---------------------------- Checking /home ownerships (Docker)"
+          make run-cmd-inside-toolchain-runner CMD="ls -la /home"
+          echo "---------------------------- Checking Propactive workspace (Docker)"
+          make run-cmd-inside-toolchain-runner CMD="ls -la /home/gradle/propactive"
+          echo "---------------------------- Creating /home/.gradle/test (Docker)"
+          make run-cmd-inside-toolchain-runner CMD="mkdir -p /home/.gradle/test"
+      - name: 'Setup Gradle caching'
+        uses: actions/cache@v3
+        with:
+          path: $HOME/.gradle
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
       - name: 'tests: propactive-jvm'
         run: make test-propactive-jvm
       - name: 'tests: propactive-plugin (acceptance)'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,10 @@
 # MAKE VARS ######################################################
 
+# Application meta-data
+APP_NAME=propactive
+# NOTE: You can always override, example: `make recipe VERSION="x.x.x"`
+VERSION?=`./scripts/version_deriver.sh`
+
 # Signing information for propactive JARs
 # https://docs.gradle.org/current/userguide/signing_plugin.html#sec:using_gpg_agent
 SIGNING_GNUPG_EXECUTABLE?=$(PROPACTIVE_SIGNING_GNUPG_EXECUTABLE)
@@ -17,32 +22,27 @@ OSSRH_PASSWORD?=$(PROPACTIVE_OSSRH_PASSWORD)
 GRADLE_PUBLISH_KEY?=$(PROPACTIVE_GRADLE_PUBLISH_KEY)
 GRADLE_PUBLISH_SECRET?=$(PROPACTIVE_GRADLE_PUBLISH_SECRET)
 
-# Application meta-data
-# NOTE: You can always override, example: `make recipe VERSION="x.x.x"`
-VERSION?=`./scripts/version_deriver.sh`
-
 # RECIPES #############################################################
 
 test-propactive-jvm:
 	@echo "******** Running tests: propactive-jvm ... ********"
-	./gradlew propactive-jvm:test --info
+	$(call toolchain_runner, ./gradlew propactive-jvm:test --info)
 
 test-acceptance-propactive-plugin:
 	@echo "******** Running tests: propactive-plugin ... ********"
-	./gradlew propactive-plugin:test --tests '*Test' --info
+	$(call toolchain_runner, ./gradlew propactive-plugin:test --tests '*Test' --info)
 
 test-integration-propactive-plugin:
 	@echo "******** Running tests: propactive-plugin ... ********"
-	./gradlew propactive-plugin:test --tests '*IT' --info
+	$(call toolchain_runner, ./gradlew propactive-plugin:test --tests '*IT' --info)
 
 check-linter:
 	@echo "******** Running linter: propactive-* ... ********"
-	./gradlew ktCh --continue
+	$(call toolchain_runner, ./gradlew ktCh --continue)
 
 build-jars:
 	@echo "******** Building JARs ... ********"
-	$(VERSION_ENVIRONMENT_VARIABLE) && \
-	./gradlew build -x test $(GPG_SIGNING_PROPERTIES) --info
+	$(call toolchain_runner, ./gradlew build -x test $(GPG_SIGNING_PROPERTIES) --info)
 
 validate-version-number:
 	@echo "******** Validating version: '$(VERSION)' ... ********"
@@ -59,30 +59,26 @@ publish-latest-version-tag: validate-version-number
 
 publish-propactive-jvm-jars: validate-version-number
 	@echo "******** Publishing JARs: propactive-jvm ... ********"
-	$(VERSION_ENVIRONMENT_VARIABLE) && \
-	$(OSSRH_ENVIRONMENT_VARIABLES) && \
-	./gradlew propactive-jvm:publishToSonatype closeAndReleaseSonatypeStagingRepository $(GPG_SIGNING_PROPERTIES) --info
+	$(call toolchain_runner, ./gradlew propactive-jvm:publishToSonatype closeAndReleaseSonatypeStagingRepository $(GPG_SIGNING_PROPERTIES) --info)
 
 publish-propactive-plugin-jars: validate-version-number
 	@echo "******** Publishing JARs: propactive-plugin ... ********"
-	$(VERSION_ENVIRONMENT_VARIABLE) && \
-	$(GRADLE_PUBLISH_ENVIRONMENT_VARIABLES) && \
-	./gradlew propactive-plugin:publishPlugins $(GPG_SIGNING_PROPERTIES) --info
+	$(call toolchain_runner, ./gradlew propactive-plugin:publishPlugins $(GPG_SIGNING_PROPERTIES) --info)
 
-# ENVIRONMENT VARIABLES ###############################################
+# APPLICATION-SPECIFIC ENVIRONMENT VARIABLES ###############################################
 
 define VERSION_ENVIRONMENT_VARIABLE
-   export VERSION=$(VERSION)
+   -e VERSION=$(VERSION)
 endef
 
 define OSSRH_ENVIRONMENT_VARIABLES
-   export OSSRH_USERNAME=$(OSSRH_USERNAME) && \
-   export OSSRH_PASSWORD=$(OSSRH_PASSWORD)
+   -e OSSRH_USERNAME=$(OSSRH_USERNAME) \
+   -e OSSRH_PASSWORD=$(OSSRH_PASSWORD)
 endef
 
 define GRADLE_PUBLISH_ENVIRONMENT_VARIABLES
-	export GRADLE_PUBLISH_KEY=$(GRADLE_PUBLISH_KEY) && \
-	export GRADLE_PUBLISH_SECRET=$(GRADLE_PUBLISH_SECRET)
+	-e GRADLE_PUBLISH_KEY=$(GRADLE_PUBLISH_KEY) \
+	-e GRADLE_PUBLISH_SECRET=$(GRADLE_PUBLISH_SECRET)
 endef
 
 # PROPERTIES ##########################################################
@@ -92,4 +88,68 @@ define GPG_SIGNING_PROPERTIES
    -Psigning.gnupg.homeDir=$(SIGNING_GNUPG_HOME_DIR) \
    -Psigning.gnupg.keyName=$(SIGNING_GNUPG_KEY_NAME) \
    -Psigning.gnupg.passphrase=$(SIGNING_GNUPG_PASSPHRASE)
+endef
+
+# TOOLCHAIN #########################################################
+
+# SETUP #####################################################
+
+# User is given by the Gradle image we are running.
+# It runs using uid/gid 1000 to avoid running as root.
+# See: https://hub.docker.com/_/gradle
+USER=gradle
+# User home directory inside the container
+USER_HOME=/home/$(USER)
+# Working directory inside the container
+PROJECT_DIR=$(USER_HOME)/$(APP_NAME)
+# Volumes to mount:
+HOST_PROJECT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+HOST_GRADLE_DATA?=$(HOME)/.gradle
+HOST_MAVEN_DATA?=$(HOME)/.m2
+# Image details
+ALPINE_GRADLE_IMAGE=gradle:8.0.2-jdk17-alpine
+# Toolchain runner container name
+TOOLCHAIN_RUNNER_CONTAINER_NAME=$(APP_NAME)-toolchain-runner
+
+# INJECTED VOLUMES #################################################
+
+# HOST_PROJECT_DIR:rw  - persist build output
+# HOST_GRADLE_DATA:rw  - cache
+# HOST_MAVEN_DATA:rw   - cache
+define TOOLCHAIN_CONTAINER_VOLUMES
+	-v $(HOST_PROJECT_DIR):$(PROJECT_DIR) \
+	-v $(HOST_GRADLE_DATA):$(USER_HOME)/.gradle:rw \
+	-v $(HOST_MAVEN_DATA):$(USER_HOME)/.m2:rw
+endef
+
+# INJECTED ENVIRONMENT #####################################################
+
+define TOOLCHAIN_CONTAINER_ENVIRONMENT_VARIABLES
+	$(VERSION_ENVIRONMENT_VARIABLE) \
+    $(OSSRH_ENVIRONMENT_VARIABLES) \
+    $(GRADLE_PUBLISH_ENVIRONMENT_VARIABLES)
+endef
+
+# RUNNER #########################################################
+
+# TOOLCHAIN Steps:
+#  1. Remove any existing/lingering toolchain runner containers
+#  2. Pull the toolchain image
+#  3. Run the container with set variables, volumes, toolchain image,
+#     and command given. (Note that the toolchain is mounted to project
+#     directory so any output generated will be written there...)
+#
+#  Usage example:
+#    $(call toolchain_runner, ./gradlew build -x test --info)
+#    $(call toolchain_runner, ./gradlew tasks)
+#
+#  See: https://www.gnu.org/software/make/manual/html_node/Call-Function.html
+define toolchain_runner
+	(docker rm -f $(TOOLCHAIN_RUNNER_CONTAINER_NAME) || true) && \
+	docker pull $(ALPINE_GRADLE_IMAGE) && \
+	docker run --rm -u gradle --name $(TOOLCHAIN_RUNNER_CONTAINER_NAME) \
+	$(TOOLCHAIN_CONTAINER_VOLUMES) \
+	$(TOOLCHAIN_CONTAINER_ENVIRONMENT_VARIABLES) \
+	-w $(PROJECT_DIR) $(ALPINE_GRADLE_IMAGE) \
+	$(1)
 endef

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,6 +89,11 @@ subprojects {
         // https://blog.gradle.org/java-toolchains
         toolchain {
             languageVersion.set(JavaLanguageVersion.of(17))
+            // NOTE:
+            //  Always ensure this matches the dockerised JDK version
+            //  To see Gradle JVM Vendor to Foojay JVM Distribution, visit:
+            //  - https://github.com/gradle/foojay-toolchains#vendors
+            vendor.set(JvmVendorSpec.ADOPTIUM)
         }
     }
 }

--- a/propactive-jvm/build.gradle.kts
+++ b/propactive-jvm/build.gradle.kts
@@ -80,6 +80,12 @@ signing {
     sign(publishing.publications["sonatype"])
 }
 
+// The Gradle Nexus plugin has a bug that requires us to manually
+// configure the signing tasks to run before the publishing tasks.
+// see: https://github.com/gradle-nexus/publish-plugin/issues/208
+val signingTasks: TaskCollection<Sign> = tasks.withType<Sign>()
+tasks.withType<PublishToMavenRepository>().configureEach { mustRunAfter(signingTasks) }
+
 tasks {
     publish {
         onlyIf { isVersionedRelease || isVersionedSnapshot }

--- a/propactive-plugin/build.gradle.kts
+++ b/propactive-plugin/build.gradle.kts
@@ -38,6 +38,12 @@ signing {
     sign(configurations.archives.get())
 }
 
+// The Gradle Nexus plugin has a bug that requires us to manually
+// configure the signing tasks to run before the publishing tasks.
+// see: https://github.com/gradle-nexus/publish-plugin/issues/208
+val signingTasks: TaskCollection<Sign> = tasks.withType<Sign>()
+tasks.withType<PublishToMavenRepository>().configureEach { mustRunAfter(signingTasks) }
+
 tasks {
     publishPlugins { onlyIf { isVersionedRelease } }
 }

--- a/propactive-plugin/src/test/kotlin/io/github/propactive/task/ApplicationPropertiesTaskIT.kt
+++ b/propactive-plugin/src/test/kotlin/io/github/propactive/task/ApplicationPropertiesTaskIT.kt
@@ -27,15 +27,25 @@ abstract class ApplicationPropertiesTaskIT(
             .parentFile
 
         // NOTE:
+        //   Sometimes a docker image might be started from Root but executing user might be different.
+        //   To ensure that the tests are executed with the same user as the docker image, we are using the
+        //   HOME environment variable to allow defining a custom user home directory for Docker images.
+        val designatedHomeDir = System
+            .getenv("HOME")
+
+        // NOTE:
         //   These tests depends on the task "publishToMavenLocal" being run before the tests are executed.
         //   Which will publish the jars locally, so we can use them in tests through MavenLocal.
         GradleConnector
             .newConnector()
+            .useGradleUserHomeDir(designatedHomeDir.let(::File))
             .forProjectDirectory(propactiveRootProject)
             .connect()
             .use { gradle ->
                 gradle
                     .newBuild()
+                    .setJvmArguments("-Duser.home=$designatedHomeDir")
+                    .setEnvironmentVariables(mapOf("HOME" to designatedHomeDir, "GRADLE_USER_HOME" to designatedHomeDir.plus("/.gradle")))
                     .forTasks("publishToMavenLocal")
                     .setStandardOutput(System.out)
                     .setStandardError(System.err)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,6 +3,19 @@ include(
     ":propactive-jvm",
 )
 
+/**
+ * The org.gradle.disco-toolchains plugin provides a repository to help auto-downloading
+ * JVMs. It is based on the foojay DiscoAPI. Requires Gradle 7.6 or later to work.
+ *
+ *  See:
+ *  - https://docs.gradle.org/current/userguide/toolchains.html#sub:download_repositories
+ *  - https://github.com/gradle/foojay-toolchains
+ */
+plugins {
+    val fooJayPluginVersion = "0.7.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version fooJayPluginVersion
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {


### PR DESCRIPTION
## Changes: 
- Fully containerise the development environment so users will only need Docker to run our Gradle JVM tests, builds, and linters.
- Build tool directory and output is fully cached so subsequent runs won't hinder performance.
- Use a minimal Ubuntu image to stay consistent with our local environment. (see: https://martinheinz.dev/blog/92)
- Use pre-built + official Gradle 8.1.1 & JVM 17 image as base image.
- Configure to optimise image caching locally and in CI.

Resolves #65 