### PR TITLE
#70 patch gradle nexus publish plugin

### DIFF
--- a/.github/workflows/TOOLCHAIN-DEPLOYMENT.yml
+++ b/.github/workflows/TOOLCHAIN-DEPLOYMENT.yml
@@ -1,0 +1,35 @@
+# Docker provides a set of official GitHub Actions for us to use in our
+# workflows to build and push images to Docker Hub and other registries.
+#
+# See: https://docs.docker.com/build/ci/github-actions/
+name: Toolchain Deployment
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ./Dockerfile
+
+env:
+  DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+  DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: 'Set up Docker Buildx'
+        uses: docker/setup-buildx-action@v3
+      - name: 'Login to Docker Hub'
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ env.DOCKER_HUB_USERNAME }}
+          password: ${{ env.DOCKER_HUB_PASSWORD }}
+      - name: 'Build and push'
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: propactive/runner:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+# Gradle's official Ubuntu JDK17 image.
+#   See:
+#     https://github.com/keeganwitt/docker-gradle/blob/master/jdk17/Dockerfile
+#   NOTE:
+#     We use a Ubuntu image instead of the slim Alpine image as official Alpine OS uses musl libc
+#     instead of the more common glibc used by most other Linux distributions. Many pre-built
+#     binaries, including many JDK distributions, expect glibc, so running Alpine risks us
+#     encounting unexpected errors and wasting time debugging them for no functional benefit.
+FROM gradle:8.1.1-jdk17-jammy
+
+# Image Metadata
+LABEL app="runner" \
+      description="Docker image to build, publish, and run the propactive framework." \
+      maintainer="U-ways (work@u-ways.info)" \
+      url="https://github.com/propactive/propactive"
+
+# Installing required packages.
+RUN apt-get update -q && \
+    apt-get install -yq --no-install-recommends gnupg gosu && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+USER root
+
+# Define $HOME directory to the gradle user's home directory so
+# our subsequent definitions have the correct $HOME as we will
+# run commands in the contianer using the gradle user.
+ARG HOME=/home/gradle
+
+# Ensure appropriate environment variables set.
+ENV GRADLE_USER_HOME=$HOME/.gradle \
+    MAVEN_HOME=$HOME/.m2 \
+    GPG_HOME=$HOME/.gnupg \
+    WORKING_DIR=$HOME/propactive
+
+# Add and set permissions for the entrypoint script
+COPY ./scripts/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+# We use the exec form of ENTRYPOINT to allows us to gracefully
+# handle SIGTERM and SIGINT signals sent to the container.
+# See: https://stackoverflow.com/a/77202288/5037430
+ENTRYPOINT ["/entrypoint.sh"]
+
+# Create necessary directories (if they don't exist)
+# and set their permissions to the gradle user.
+RUN mkdir -p \
+      $GRADLE_USER_HOME \
+      $MAVEN_HOME \
+      $GPG_HOME \
+      $WORKING_DIR && \
+    chown -R gradle:gradle $HOME
+
+# Specify volume mount points to avoid accidental data persistence in anonymous volumes.
+VOLUME ["$MAVEN_HOME", "$GRADLE_USER_HOME", "$GPG_HOME", "$WORKING_DIR"]
+
+# Set the working directory to the project's directory.
+WORKDIR $WORKING_DIR
+
+# Default command to run when the container starts.
+CMD ["./gradlew", "tasks"]

--- a/Makefile
+++ b/Makefile
@@ -1,48 +1,42 @@
-# MAKE VARS ######################################################
+################################################################################################
+# Propactive Makefile
+#
+# This Makefile is split into two sections:
+#   - Application: for building, testing, and publishing the project.
+#   - Toolchain: for building, testing, and publishing the toolchain that is used to run the project.
+#
+# The application section is intended to be used by developers and contributors to the project.
+# The toolchain section is intended to be used by maintainers of the project.
+#
+# We write our rule names in the following format: [verb]-[noun]-[noun], e.g. "build-jars".
+#
+# Application ##################################################################################
 
-# Application meta-data
-APP_NAME=propactive
-# NOTE: You can always override, example: `make [recipe] VERSION="x.x.x"`
-VERSION?=`./scripts/version_deriver.sh`
-
-# Signing information for propactive JARs
-# https://docs.gradle.org/current/userguide/signing_plugin.html#sec:using_gpg_agent
-SIGNING_GNUPG_EXECUTABLE?=$(PROPACTIVE_SIGNING_GNUPG_EXECUTABLE)
-SIGNING_GNUPG_HOME_DIR?=$(PROPACTIVE_SIGNING_GNUPG_HOME_DIR)
-SIGNING_GNUPG_KEY_NAME?=$(PROPACTIVE_SIGNING_GNUPG_KEY_NAME)
-SIGNING_GNUPG_PASSPHRASE?=$(PROPACTIVE_SIGNING_GNUPG_PASSPHRASE)
-
-# Authentication details for SonaType repositories
-# https://central.sonatype.org/publish/publish-gradle/#deploying-to-ossrh-with-gradle-introduction
-OSSRH_USERNAME?=$(PROPACTIVE_OSSRH_USERNAME)
-OSSRH_PASSWORD?=$(PROPACTIVE_OSSRH_PASSWORD)
-
-# Authentication details for Gradle Plugin Portal
-# https://plugins.gradle.org/docs/publish-plugin#portal-setup
-GRADLE_PUBLISH_KEY?=$(PROPACTIVE_GRADLE_PUBLISH_KEY)
-GRADLE_PUBLISH_SECRET?=$(PROPACTIVE_GRADLE_PUBLISH_SECRET)
-
-# RECIPES #############################################################
+# RECIPES
 
 test-propactive-jvm:
 	@echo "******** Running tests: propactive-jvm ... ********"
-	$(call toolchain_runner, ./gradlew propactive-jvm:test --info)
+	$(call toolchain_runner,./gradlew propactive-jvm:test --info)
 
 test-acceptance-propactive-plugin:
 	@echo "******** Running tests: propactive-plugin ... ********"
-	$(call toolchain_runner, ./gradlew propactive-plugin:test --tests '*Test' --info)
+	$(call toolchain_runner,./gradlew propactive-plugin:test --tests *Test --info)
 
 test-integration-propactive-plugin:
 	@echo "******** Running tests: propactive-plugin ... ********"
-	$(call toolchain_runner, ./gradlew propactive-plugin:test --tests '*IT' --info)
+	$(call toolchain_runner,./gradlew propactive-plugin:test --tests *IT --info)
 
 check-linter:
 	@echo "******** Running linter: propactive-* ... ********"
-	$(call toolchain_runner, ./gradlew ktCh --continue)
+	$(call toolchain_runner,./gradlew ktCh --continue)
 
 build-jars:
 	@echo "******** Building JARs ... ********"
-	$(call toolchain_runner, ./gradlew build -x test $(GPG_SIGNING_PROPERTIES) --info)
+	$(call toolchain_runner,./gradlew build -x test $(GPG_SIGNING_PROPERTIES) --info)
+
+build-jars-no-signing:
+	@echo "******** Building JARs (without signing)... ********"
+	$(call toolchain_runner,./gradlew build -x test --info)
 
 validate-version-number:
 	@echo "******** Validating version: '$(VERSION)' ... ********"
@@ -59,138 +53,142 @@ publish-latest-version-tag: validate-version-number
 
 publish-propactive-jvm-jars: validate-version-number
 	@echo "******** Publishing JARs: propactive-jvm ... ********"
-	$(call toolchain_runner, ./gradlew propactive-jvm:publishToSonatype closeAndReleaseSonatypeStagingRepository $(GPG_SIGNING_PROPERTIES) --info)
+	$(call toolchain_runner,./gradlew propactive-jvm:publishToSonatype closeAndReleaseSonatypeStagingRepository $(GPG_SIGNING_PROPERTIES) --info)
 
 publish-propactive-plugin-jars: validate-version-number
 	@echo "******** Publishing JARs: propactive-plugin ... ********"
-	$(call toolchain_runner, ./gradlew propactive-plugin:publishPlugins $(GPG_SIGNING_PROPERTIES) --info)
+	$(call toolchain_runner,./gradlew propactive-plugin:publishPlugins $(GPG_SIGNING_PROPERTIES) --info)
 
-# APPLICATION-SPECIFIC ENVIRONMENT VARIABLES ###############################################
+# VARIABLES
 
-define VERSION_ENVIRONMENT_VARIABLE
-   -e VERSION=$(VERSION)
-endef
+APP_NAME=propactive
+VERSION?=`./scripts/version_deriver.sh`
 
-define OSSRH_ENVIRONMENT_VARIABLES
-   -e OSSRH_USERNAME=$(OSSRH_USERNAME) \
-   -e OSSRH_PASSWORD=$(OSSRH_PASSWORD)
-endef
+# Authentication details for SonaType repositories
+# https://central.sonatype.org/publish/publish-gradle/#deploying-to-ossrh-with-gradle-introduction
+OSSRH_USERNAME?=$(PROPACTIVE_OSSRH_USERNAME)
+OSSRH_PASSWORD?=$(PROPACTIVE_OSSRH_PASSWORD)
 
-define GRADLE_PUBLISH_ENVIRONMENT_VARIABLES
-	-e GRADLE_PUBLISH_KEY=$(GRADLE_PUBLISH_KEY) \
-	-e GRADLE_PUBLISH_SECRET=$(GRADLE_PUBLISH_SECRET)
-endef
+# Authentication details for Gradle Plugin Portal
+# https://plugins.gradle.org/docs/publish-plugin#portal-setup
+GRADLE_PUBLISH_KEY?=$(PROPACTIVE_GRADLE_PUBLISH_KEY)
+GRADLE_PUBLISH_SECRET?=$(PROPACTIVE_GRADLE_PUBLISH_SECRET)
 
-# PROPERTIES ##########################################################
+# Signing information for propactive JARs
+# https://docs.gradle.org/current/userguide/signing_plugin.html#sec:using_gpg_agent
+SIGNING_GNUPG_EXECUTABLE?=$(PROPACTIVE_SIGNING_GNUPG_EXECUTABLE)
+SIGNING_GNUPG_HOME_DIR?=$(PROPACTIVE_SIGNING_GNUPG_HOME_DIR)
+SIGNING_GNUPG_KEY_NAME?=$(PROPACTIVE_SIGNING_GNUPG_KEY_NAME)
+SIGNING_GNUPG_PASSPHRASE?=$(PROPACTIVE_SIGNING_GNUPG_PASSPHRASE)
 
 define GPG_SIGNING_PROPERTIES
-   -Psigning.gnupg.executable=$(SIGNING_GNUPG_EXECUTABLE) \
-   -Psigning.gnupg.homeDir=$(SIGNING_GNUPG_HOME_DIR) \
-   -Psigning.gnupg.keyName=$(SIGNING_GNUPG_KEY_NAME) \
-   -Psigning.gnupg.passphrase=$(SIGNING_GNUPG_PASSPHRASE)
+ -Psigning.gnupg.executable=$(SIGNING_GNUPG_EXECUTABLE) \
+ -Psigning.gnupg.homeDir=$(SIGNING_GNUPG_HOME_DIR) \
+ -Psigning.gnupg.keyName=$(SIGNING_GNUPG_KEY_NAME) \
+ -Psigning.gnupg.passphrase=$(SIGNING_GNUPG_PASSPHRASE)
 endef
 
-# TOOLCHAIN #########################################################
+# TOOLCHAIN ##################################################################################
 
-# SETUP #####################################################
+# RECIPES
 
-# Although the Gradle image has a user named "gradle",
-# We might need to use the "root" user here because GH actions
-# uid/gid is not 1000. Meaning that the "gradle" user
-# won't have access to the mounted volumes.
-# See: https://hub.docker.com/_/gradle
-DOCKER_USER=gradle
-DOCKER_USER_HOME=/home/$(DOCKER_USER)
-DOCKER_PROJECT_DIR=$(DOCKER_USER_HOME)/$(APP_NAME)
+login-to-docker-hub:
+	@echo "******** Logging in to Docker Hub ... ********"
+	@echo "$(DOCKER_HUB_PASSWORD)" | docker login -u "$(DOCKER_HUB_USERNAME)" --password-stdin
 
-# Host volumes to mount:
+build-toolchain:
+	@echo "******** Building toolchain image ... ********"
+	docker build -t $(TOOLCHAIN_IMAGE_ID) -f ./Dockerfile .
+
+publish-toolchain: build-toolchain login-to-docker-hub
+	@echo "******** Publishing toolchain image ... ********"
+	docker push $(TOOLCHAIN_IMAGE_ID)
+
+login-toolchain:
+	@echo "******** Running toolchain image as an interactive shell ... ********"
+	@$(call toolchain_runner,bash -li,-it -e TERM='xterm-256color' -h '[Propactive|Runner]')
+
+# Example: make toolchain-exec cmd="ls -la"
+exec-toolchain:
+	@$(call toolchain_runner,$(cmd))
+
+# VARIABLES
+
+# TIP: Do you wanna avoid pulling the toolchain image every time you run a command?
+#      Set the TOOLCHAIN_IMAGE_VERSION to a specific version, e.g. "snapshot", and run "make build-toolchain-image".
+#      Then, you will have a local image that you can use for running commands that isn't constantly being updated
+#      As it's not latest.
+TOOLCHAIN_IMAGE_VERSION?=latest
+TOOLCHAIN_IMAGE_ID=propactive/runner:$(TOOLCHAIN_IMAGE_VERSION)
+TOOLCHAIN_CONTAINER_NAME=$(APP_NAME)-runner
+
+DOCKER_HUB_USERNAME?=$(PROPACTIVE_DOCKER_HUB_USERNAME)
+DOCKER_HUB_PASSWORD?=$(PROPACTIVE_DOCKER_HUB_PASSWORD)
+
+DOCKER_HOME_DIR=/home/gradle
+DOCKER_PROJECT_DIR=$(DOCKER_HOME_DIR)/propactive
+DOCKER_GRADLE_DATA=$(DOCKER_HOME_DIR)/.gradle
+DOCKER_MAVEN_DATA=$(DOCKER_HOME_DIR)/.m2
+
 HOST_PROJECT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 HOST_GRADLE_DATA?=$(HOME)/.gradle
 HOST_MAVEN_DATA?=$(HOME)/.m2
 
-# IMAGE DETAILS #################################################
+# INJECTED VOLUMES
 
-# Gradle's official Ubuntu JDK17 image.
-#   See:
-#     https://github.com/keeganwitt/docker-gradle/blob/master/jdk17/Dockerfile
-#   NOTE:
-#     Use a Ubuntu image instead of Linux Alpine as official Alpine uses musl libc
-#     instead of the more common glibc used by most other Linux distributions. (Many pre-built
-#     binaries, including many JDK distributions, expect glibc, so running Alpine risks running
-#     into unexpected errors)
-DOCKER_GRADLE_IMAGE=gradle:8.1.1-jdk17-jammy
-# Toolchain runner container name
-TOOLCHAIN_RUNNER_CONTAINER_NAME=$(APP_NAME)-toolchain-runner
-
-# INJECTED VOLUMES #################################################
-
-# HOST_PROJECT_DIR:rw  - persist build output
-# HOST_GRADLE_DATA:rw  - cache
-# HOST_MAVEN_DATA:rw   - cache
 define TOOLCHAIN_CONTAINER_VOLUMES
-	-v $(HOST_PROJECT_DIR):$(DOCKER_PROJECT_DIR) \
-	-v $(HOST_GRADLE_DATA):$(DOCKER_USER_HOME)/.gradle:rw \
-	-v $(HOST_MAVEN_DATA):$(DOCKER_USER_HOME)/.m2:rw
+ -v $(HOST_PROJECT_DIR):$(DOCKER_PROJECT_DIR):rw \
+ -v $(HOST_GRADLE_DATA):$(DOCKER_GRADLE_DATA):rw \
+ -v $(HOST_MAVEN_DATA):$(DOCKER_MAVEN_DATA):rw
 endef
 
-# INJECTED ENVIRONMENT #####################################################
+# INJECTED ENVIRONMENT VARIABLES
+
+define VERSION_ENVIRONMENT_VARIABLE
+ -e VERSION=$(VERSION)
+endef
+
+define OSSRH_ENVIRONMENT_VARIABLES
+ -e OSSRH_USERNAME=$(OSSRH_USERNAME) \
+ -e OSSRH_PASSWORD=$(OSSRH_PASSWORD)
+endef
+
+define GRADLE_PUBLISH_ENVIRONMENT_VARIABLES
+ -e GRADLE_PUBLISH_KEY=$(GRADLE_PUBLISH_KEY) \
+ -e GRADLE_PUBLISH_SECRET=$(GRADLE_PUBLISH_SECRET)
+endef
+
+# See: scripts/entrypoint.sh
+define DOCKER_USER_UID_GID_MATCHER
+ -e SET_DOCKER_USER_UID=$(shell id -u) \
+ -e SET_DOCKER_USER_GID=$(shell id -g)
+endef
 
 define TOOLCHAIN_CONTAINER_ENVIRONMENT_VARIABLES
-	$(VERSION_ENVIRONMENT_VARIABLE) \
-    $(OSSRH_ENVIRONMENT_VARIABLES) \
-    $(GRADLE_PUBLISH_ENVIRONMENT_VARIABLES)
+ $(VERSION_ENVIRONMENT_VARIABLE) \
+ $(DOCKER_USER_UID_GID_MATCHER) \
+ $(OSSRH_ENVIRONMENT_VARIABLES) \
+ $(GRADLE_PUBLISH_ENVIRONMENT_VARIABLES)
 endef
 
-# ID MATCHER #################################################
+# FUNCTIONS
 
-# Match user's UID and GID (i.e. correct access to cached files)
-HOST_UID=`id -u`
-HOST_GID=`id -g`
-
-# The GitHub Actions runner uses a non-standard UID/GID
-# which causes permission issues when mounting volumes.
-# Below definition will change the UID/GID of the "gradle"
-# user in the image to match the host's UID/GID.
-#
-# We then run the provided command as the "gradle" user.
-define MATCH_HOST_UID_GID
-	usermod -u "$(HOST_UID)" gradle && \
-	groupmod -g "$(HOST_GID)" gradle
+# 1. Ensure there are no lingering toolchain runner containers
+# 2.1. If the version is "latest", always pull the toolchain image.
+# 2.2. If the version is not "latest", check if the toolchain image exists, and pull if not.
+define ensure_clean_toolchain_runner_environment
+ docker rm -f $(TOOLCHAIN_CONTAINER_NAME) > /dev/null 2>&1 || true; \
+ if [ "$(TOOLCHAIN_IMAGE_VERSION)" = "latest" ]; then \
+    docker pull $(TOOLCHAIN_IMAGE_ID); \
+ else \
+    docker image inspect $(TOOLCHAIN_IMAGE_ID) > /dev/null 2>&1 || docker pull $(TOOLCHAIN_IMAGE_ID); \
+ fi
 endef
 
-# USER MATCHER #################################################
-
-# Our docker image runs as root (so we can modify gradle's UID and GID to match
-# our CI runner IDs) this means once we execute our commands on user switch,
-# we need to ensure the environment variables Gradle relies on are updated
-# accordingly.
-#
-# See: https://docs.gradle.org/current/userguide/build_environment.html
-define GRADLE_USER_MATCHER
-    -e GRADLE_USER_HOME=$(DOCKER_USER_HOME)/.gradle \
-    -e HOME=$(DOCKER_USER_HOME)
-endef
-
-# RUNNER #########################################################
-
-# TOOLCHAIN Steps:
-#  1. Remove any existing/lingering toolchain runner containers
-#  2. Pull the toolchain image
-#  3. Run the container with set variables, volumes, toolchain image,
-#     and command given. (Note that the toolchain is mounted to project
-#     directory so any output generated will be written there...)
-#
-#  Usage example:
-#    $(call toolchain_runner, ./gradlew build -x test --info)
-#    $(call toolchain_runner, ./gradlew tasks)
-#
-#  See: https://www.gnu.org/software/make/manual/html_node/Call-Function.html
 define toolchain_runner
-	(docker rm -f $(TOOLCHAIN_RUNNER_CONTAINER_NAME) || true) && \
-	docker pull $(DOCKER_GRADLE_IMAGE) && \
-	docker run --rm -u root --name $(TOOLCHAIN_RUNNER_CONTAINER_NAME) \
-	$(TOOLCHAIN_CONTAINER_VOLUMES) \
-	$(TOOLCHAIN_CONTAINER_ENVIRONMENT_VARIABLES) \
-	$(GRADLE_USER_MATCHER) \
-	-w $(DOCKER_PROJECT_DIR) $(DOCKER_GRADLE_IMAGE) sh -c "$(MATCH_HOST_UID_GID) && su gradle && $(1)"
+ $(call ensure_clean_toolchain_runner_environment) && \
+ docker run $(2) --rm --name $(TOOLCHAIN_CONTAINER_NAME) \
+ $(TOOLCHAIN_CONTAINER_VOLUMES) \
+ $(TOOLCHAIN_CONTAINER_ENVIRONMENT_VARIABLES) \
+ $(TOOLCHAIN_IMAGE_ID) "$(1)"
 endef

--- a/propactive-plugin/build.gradle.kts
+++ b/propactive-plugin/build.gradle.kts
@@ -38,12 +38,6 @@ signing {
     sign(configurations.archives.get())
 }
 
-// The Gradle Nexus plugin has a bug that requires us to manually
-// configure the signing tasks to run before the publishing tasks.
-// see: https://github.com/gradle-nexus/publish-plugin/issues/208
-val signingTasks: TaskCollection<Sign> = tasks.withType<Sign>()
-tasks.withType<PublishToMavenRepository>().configureEach { mustRunAfter(signingTasks) }
-
 tasks {
     publishPlugins { onlyIf { isVersionedRelease } }
 }

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# shellcheck disable=SC2086
+# Some CI runners do not have the standard UID and GID values (i.e. 1000:1000)
+# This causes permission issues when mounting volumes and running commands as
+# a standard user.
+#
+# To work around this, we allow the user to specify custom UID and GID values via:
+# - Change UID:  `-e SET_DOCKER_USER_UID=$(shell id -u)`
+# - Change GID:  `-e SET_DOCKER_USER_GID=$(shell id -g)`
+#
+# And we also let them provide a custom username to run the commands via:
+# - Change user: `-e SET_DOCKER_USER=$(shell whoami)`
+#
+# Usecase example:
+#   - The GitHub Actions runner uses a non-standard UID/GID to run
+#     docker containers, this causes permission issues when mounting volumes.
+
+# In our context, the default user is the one built by the official
+# Gradle Docker image, see: https://hub.docker.com/_/gradle
+DEFAULT_USER="gradle"
+DEFAULT_USER_UID="$(id -u $DEFAULT_USER)"
+DEFAULT_USER_GID="$(id -g $DEFAULT_USER)"
+
+USER="${SET_DOCKER_USER:-$DEFAULT_USER}"
+
+# Check if the user exists, if not, create the user
+if ! id "$USER" &>/dev/null; then
+    echo "User $USER does not exist, and not the default ($DEFAULT_USER) user, creating user..."
+    useradd -m "$USER";
+fi
+
+# Update the UID and GID if specified and they're not matching
+if [ -n "$SET_DOCKER_USER_UID" ] && [ "$DEFAULT_USER_UID" != "$SET_DOCKER_USER_UID" ]; then
+    echo "Given UID: $SET_DOCKER_USER_UID, does not match the default UID: $DEFAULT_USER_UID"
+    echo "Changing UID from $DEFAULT_USER_UID to $SET_DOCKER_USER_UID"
+    usermod  -u "$SET_DOCKER_USER_UID" $USER;
+    echo "Also changing user ownership of /home/$USER to UID $SET_DOCKER_USER_UID"
+    chown -R "$SET_DOCKER_USER_UID" "/home/$USER"
+fi
+if [ -n "$SET_DOCKER_USER_GID"  ] && [ "$DEFAULT_USER_GID" != "$SET_DOCKER_USER_GID" ]; then
+    echo "Given GID: $SET_DOCKER_USER_GID, does not match the default GID: $DEFAULT_USER_GID"
+    echo "Changing GID from $DEFAULT_USER_GID to $SET_DOCKER_USER_GID"
+    groupmod -g "$SET_DOCKER_USER_GID" $USER;
+    echo "Also changing group ownership of /home/$USER to GID $SET_DOCKER_USER_GID"
+    chgrp -R "$SET_DOCKER_USER_GID" "/home/$USER"
+fi
+
+# Run the provided command as the specified (or default) user
+# see: https://github.com/tianon/gosu
+# shellcheck disable=SC2068 # NOTE: We allow the user to pass in arguments to the entrypoint, just be careful with quotation marks.
+exec gosu $USER $@


### PR DESCRIPTION
## Summary

A lot of DevOps changes here, no functional changes for Propactive.

- The CD pipeline is now enabled again.
- As part of this ticket, the CI/CD workflows can now be manually triggered on demand. (useful for debugging and non-production code changes pipeline testing)
- Created our own Docker image, which now lives in [hub.docker.com/u/propactive](https://hub.docker.com/u/propactive)
- Complete rewrite of our project's toolchain / `Makefile` to incorporate the simplifications the new image provide.

#### Image Details

This was long due as the goal of our containerised toolchain is not just environment isolation, I wanted to give myself, and future contributors the ability to seamlessly modify the project's source code and tests without having to rely on their local environment to have the correct binaries to run the project.

Part of this work was done in #65 , however, it didn't take me long to realise mounting files with different UID and GID, runners with different UID and GID, signing jars relying on host's installed GPG, and Unix signals not being respected due to wrapping the docker runs with "sh -c ..." has still left much to be desired.

Previously, I was wrapping all of our Makefile rules with complex instructions to ensure the UID and GID of the files created by the container are the same as the host's user, and at one point I thought I might as well install GPG in the running container everytime for signing jars, but that's not a good practice, and defeats the purpose of having a ready-made containerised toolchain.

So to further improve our toolchain and simplify our Makefile, a new docker image and Entrypoint script addition has been built to address those issues. The new image is based on the official Gradle JDK17 image, with the addition of GPG, [GOSU](https://github.com/tianon/gosu), and a new Entrypoint script that will ensure the UID and GID of the files created by the container are the same as the host's user, and respect Unix signals.

On top of that many of the environment variables that were previously set in the Makefile are now set in the Dockerfile, and the Makefile has been simplified to just a few lines.

Finally, to ease maintenance, a TOOLCHAIN-DEPLOYMENT.yml workflow has been created to build and push the image whenever the Dockerfile is modified :)

___