### PR TITLE
#78  - containerise deployment environment

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -22,13 +22,11 @@ jobs:
     steps:
       - name: 'Checkout to current branch'
         uses: actions/checkout@v3
-      - name: 'Importing GPG key'
-        uses: crazy-max/ghaction-import-gpg@v5
-        with:
-          gpg_private_key: ${{ env.SIGNING_GNUPG_PRIVATE_KEY }}
-          passphrase: ${{ env.SIGNING_GNUPG_KEY_NAME }}
+      - name: 'Escape newlines in GPG private key (required for Makefile tooling)'
+        id: escape_newlines
+        run: ./scripts/escape_newlines.sh "${{ secrets.SIGNING_GNUPG_PRIVATE_KEY }}" >> $GITHUB_OUTPUT
       - name: 'Building Project JARs'
-        run: make build-jars
+        run: make build-jars SIGNING_GNUPG_PRIVATE_KEY="${{ steps.escape_newlines.outputs.escaped_key }}"
       - name: 'Uploading propactive-jvm JAR artifacts'
         uses: actions/upload-artifact@v3
         with:
@@ -52,14 +50,9 @@ jobs:
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-      - name: 'Importing GPG key'
-        uses: crazy-max/ghaction-import-gpg@v5
-        with:
-          gpg_private_key: ${{ env.SIGNING_GNUPG_PRIVATE_KEY }}
-          passphrase: ${{ env.SIGNING_GNUPG_KEY_NAME }}
       - name: 'Publishing latest version tag'
         run: make publish-latest-version-tag
       - name: 'Publishing to maven central'
-        run: make publish-propactive-jvm-jars
+        run: make publish-propactive-jvm-jars SIGNING_GNUPG_PRIVATE_KEY="${{ needs.Prepare-JARs.outputs.escaped_key }}"
       - name: 'Publishing to gradle plugin'
-        run: make publish-propactive-plugin-jars
+        run: make publish-propactive-plugin-jars SIGNING_GNUPG_PRIVATE_KEY="${{ needs.Prepare-JARs.outputs.escaped_key }}"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -18,10 +18,10 @@ jobs:
       - name: 'tests: propactive-plugin (integration)'
         run: make test-integration-propactive-plugin
       # TMP: #70 This should be removed once gradle-nexus/publish-plugin/issues/208 is fixed
-      - name: 'A timebomb to address #70 on the 01/10/2023'
+      - name: 'A timebomb to address #70 on the 2023-12-01'
         run: |
-          if [[ $(date +%s) -gt 1696114800 ]]; then
-            echo "It has been 1 month since #70 was opened."
+          if [[ $(date +%s) -gt 1701388800 ]]; then
+            echo "It has been many months since #70 was opened."
             echo "Please check if gradle-nexus/publish-plugin/issues/208 has been fixed."
             echo "  If it has, please update the plugin and re-enable the CD workflow."
             echo "  else, please increase this timebomb by 1 month."

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ check-linter:
 
 build-jars:
 	@echo "******** Building JARs ... ********"
-	$(call toolchain_runner,./gradlew build -x test $(GPG_SIGNING_PROPERTIES) --info)
+	@$(call toolchain_runner,./gradlew build -x test $(GPG_SIGNING_PROPERTIES) --info,-e GPG_PRIVATE_KEY="$(SIGNING_GNUPG_PRIVATE_KEY)" -e GPG_PRIVATE_KEY_PASSPHRASE="$(SIGNING_GNUPG_PASSPHRASE)")
 
 build-jars-no-signing:
 	@echo "******** Building JARs (without signing)... ********"
@@ -53,11 +53,11 @@ publish-latest-version-tag: validate-version-number
 
 publish-propactive-jvm-jars: validate-version-number
 	@echo "******** Publishing JARs: propactive-jvm ... ********"
-	$(call toolchain_runner,./gradlew propactive-jvm:publishToSonatype closeAndReleaseSonatypeStagingRepository $(GPG_SIGNING_PROPERTIES) --info)
+	@$(call toolchain_runner,./gradlew propactive-jvm:publishToSonatype closeAndReleaseSonatypeStagingRepository $(GPG_SIGNING_PROPERTIES) --info,-e GPG_PRIVATE_KEY="$(SIGNING_GNUPG_PRIVATE_KEY)" -e GPG_PRIVATE_KEY_PASSPHRASE="$(SIGNING_GNUPG_PASSPHRASE)")
 
 publish-propactive-plugin-jars: validate-version-number
 	@echo "******** Publishing JARs: propactive-plugin ... ********"
-	$(call toolchain_runner,./gradlew propactive-plugin:publishPlugins $(GPG_SIGNING_PROPERTIES) --info)
+	@$(call toolchain_runner,./gradlew propactive-plugin:publishPlugins $(GPG_SIGNING_PROPERTIES) --info,-e GPG_PRIVATE_KEY="$(SIGNING_GNUPG_PRIVATE_KEY)" -e GPG_PRIVATE_KEY_PASSPHRASE="$(SIGNING_GNUPG_PASSPHRASE)")
 
 # VARIABLES
 
@@ -80,6 +80,7 @@ SIGNING_GNUPG_EXECUTABLE?=$(PROPACTIVE_SIGNING_GNUPG_EXECUTABLE)
 SIGNING_GNUPG_HOME_DIR?=$(PROPACTIVE_SIGNING_GNUPG_HOME_DIR)
 SIGNING_GNUPG_KEY_NAME?=$(PROPACTIVE_SIGNING_GNUPG_KEY_NAME)
 SIGNING_GNUPG_PASSPHRASE?=$(PROPACTIVE_SIGNING_GNUPG_PASSPHRASE)
+SIGNING_GNUPG_PRIVATE_KEY?=$(PROPACTIVE_SIGNING_GNUPG_PRIVATE_KEY)
 
 define GPG_SIGNING_PROPERTIES
  -Psigning.gnupg.executable=$(SIGNING_GNUPG_EXECUTABLE) \
@@ -108,7 +109,7 @@ login-toolchain:
 	@echo "******** Running toolchain image as an interactive shell ... ********"
 	@$(call toolchain_runner,bash -li,-it -e TERM='xterm-256color' -h '[Propactive|Runner]')
 
-# Example: make toolchain-exec cmd="ls -la"
+# Example: make exec-toolchain cmd="ls -la"
 exec-toolchain:
 	@$(call toolchain_runner,$(cmd))
 

--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,10 @@ publish-propactive-plugin-jars: validate-version-number
 	@echo "******** Publishing JARs: propactive-plugin ... ********"
 	@$(call toolchain_runner,./gradlew propactive-plugin:publishPlugins $(GPG_SIGNING_PROPERTIES) --info,-e GPG_PRIVATE_KEY="$(SIGNING_GNUPG_PRIVATE_KEY)" -e GPG_PRIVATE_KEY_PASSPHRASE="$(SIGNING_GNUPG_PASSPHRASE)")
 
+publish-propactive-to-maven-local: validate-version-number
+	@echo "******** Publishing JARs To Maven local ... ********"
+	@$(call toolchain_runner,./gradlew publishToMavenLocal $(GPG_SIGNING_PROPERTIES) --info,-e GPG_PRIVATE_KEY="$(SIGNING_GNUPG_PRIVATE_KEY)" -e GPG_PRIVATE_KEY_PASSPHRASE="$(SIGNING_GNUPG_PASSPHRASE)")
+
 # VARIABLES
 
 APP_NAME=propactive

--- a/scripts/escape_newlines.sh
+++ b/scripts/escape_newlines.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#================================================================
+# HEADER
+#================================================================
+#% SYNOPSIS
+#+    escape_newlines.sh "<string>"
+#%
+#% DESCRIPTION
+#%    This script converts newline characters in a string to
+#%    the literal string '\n'. This is useful when you want to
+#%    preserve the multiline format of a string when passing it
+#%    as a single-line string to another process.
+#%
+#% EXAMPLES
+#%    ./escape_newlines.sh "Line1
+#%    Line2"
+#================================================================
+# END_OF_HEADER
+#================================================================
+
+input="$1"  # Capture the argument passed to this script
+
+# Use sed to replace newline characters with the string '\n'
+echo "$input" | sed ':a;N;$!ba;s/\n/\\n/g'


### PR DESCRIPTION
## Changes

Follow up on #65 , we now fully containerise the deployment environment, in which the only thing was missing for this is handling the GPG key importing in our toolchain image. 

Since we don't want to build our toolcahin images with the private key pre-loaded (insecure), we had to add support for:
1. Passing the `GPG_PRIVATE_KEY` and `GPG_PRIVATE_KEY_PASSPHRASE` to the container on docker run.
2. Importing the GPG private key for the docker user when key is provided.
3. Setting safe permissions on `$GPG_HOME_DIR`...

One notable challenge here was injecting the key to Makefile rule without breaking syntax (i.e. Makefile has bad support for multi line arguments for complex rules). This was resolved by escaping the new lines in the private key. (It is also possible to solve this by passing the private key using [docker's --env-file](https://docs.docker.com/compose/environment-variables/env-file/))

## Summary
- Introduced support for containerised GPG signing.
- Use containerised GPG signing in our CD workflow to eliminate external GPG import plugin dependency.
- EXTRA: Increased #70 timebomb to 1 more month.
- EXTRA: Allow publishing to maven local using Make rules. (useful for testing GPG signed artifacts without needing to rely on local environment)

Resolves #78 
