### PR TITLE
76 automate dependency management maintenance

### DIFF
--- a/.github/workflows/MANUAL-RENOVATE.yml
+++ b/.github/workflows/MANUAL-RENOVATE.yml
@@ -1,0 +1,20 @@
+name: MANUAL-RENOVATE
+
+on: [
+  workflow_dispatch
+]
+
+jobs:
+  manual-renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout to current branch'
+        uses: actions/checkout@v4
+      - name: 'Setup Node.js'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: 'Install Renovate globally'
+        run: npm install -g renovate
+      - name: 'Run Renovate on current branch'
+        run: renovate

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,60 @@
+{
+    "extends": ["config:recommended", ":semanticCommits"],
+    "labels": [ "dependencies" ],
+    "schedule": [ "after 5pm on saturday and sunday" ],
+    "dependencyDashboard": true,
+    "gradle": {
+        "enabled": true,
+        "path": "settings.gradle.kts"
+    },
+    "gradle-wrapper": {
+        "enabled": true,
+        "path": "gradle/wrapper/gradle-wrapper.properties"
+    },
+    "dockerfile": {
+        "enabled": true,
+        "pinDigests": true,
+        "path": "Dockerfile"
+    },
+    "packageRules": [
+        {
+            "matchUpdateTypes": ["major"],
+            "dependencyDashboardApproval": true
+        },
+        {
+            "matchPackagePatterns": ["^org.jetbrains.kotlin"],
+            "automerge": true,
+            "automergeType": "branch",
+            "matchUpdateTypes": ["minor", "patch"],
+            "groupName": "Kotlin dependencies"
+        },
+        {
+            "matchPackagePatterns": ["^log4j"],
+            "automerge": true,
+            "automergeType": "branch",
+            "matchUpdateTypes": ["minor", "patch"],
+            "groupName": "Log4j dependencies"
+        },
+        {
+            "matchPackagePatterns": ["^kotest"],
+            "automerge": true,
+            "automergeType": "branch",
+            "matchUpdateTypes": ["minor", "patch"],
+            "groupName": "Kotest dependencies"
+        },
+        {
+            "matchPackagePatterns": ["^junit"],
+            "automerge": true,
+            "automergeType": "branch",
+            "matchUpdateTypes": ["minor", "patch"],
+            "groupName": "Junit dependencies"
+        },
+        {
+            "matchPackagePatterns": ["^gradle-publish"],
+            "automerge": true,
+            "automergeType": "branch",
+            "matchUpdateTypes": ["minor", "patch"],
+            "groupName": "Gradle publish dependencies"
+        }
+    ]
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,17 +32,16 @@ dependencyResolutionManagement {
             val log4jKotlinVersion = "1.3.0"
             val log4jVersion = "2.20.0"
 
-            library("kotlin-reflect", "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
-            library("kotlin-stdlib", "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
-            library("kotlinx-serialization-json", "org.jetbrains.kotlinx:kotlinx-serialization-json:$serializationVersion")
-            library("mockk", "io.mockk:mockk:$mockkVersion")
-            library("kotest-runner-junit5", "io.kotest:kotest-runner-junit5:$kotestVersion")
-            library("kotest-assertions-core", "io.kotest:kotest-assertions-core:$kotestVersion")
-            library("junit-jupiter", "org.junit.jupiter:junit-jupiter:$junitVersion")
-            library("equalsverifier", "nl.jqno.equalsverifier:equalsverifier:$equalsVersion")
-
-            library("log4j-api-kotlin", "org.apache.logging.log4j:log4j-api-kotlin:$log4jKotlinVersion")
-            library("log4j-core", "org.apache.logging.log4j:log4j-core:$log4jVersion")
+            library("kotlin-reflect", "org.jetbrains.kotlin", "kotlin-reflect").version(kotlinVersion)
+            library("kotlin-stdlib", "org.jetbrains.kotlin", "kotlin-stdlib").version(kotlinVersion)
+            library("kotlinx-serialization-json", "org.jetbrains.kotlinx", "kotlinx-serialization-json").version(serializationVersion)
+            library("mockk", "io.mockk", "mockk").version(mockkVersion)
+            library("kotest-runner-junit5", "io.kotest", "kotest-runner-junit5").version(kotestVersion)
+            library("kotest-assertions-core", "io.kotest", "kotest-assertions-core").version(kotestVersion)
+            library("junit-jupiter", "org.junit.jupiter", "junit-jupiter").version(junitVersion)
+            library("equalsverifier", "nl.jqno.equalsverifier", "equalsverifier").version(equalsVersion)
+            library("log4j-api-kotlin", "org.apache.logging.log4j", "log4j-api-kotlin").version(log4jKotlinVersion)
+            library("log4j-core", "org.apache.logging.log4j", "log4j-core").version(log4jVersion)
 
             plugin("jetbrains-kotlin-jvm", "org.jetbrains.kotlin.jvm").version(kotlinVersion)
             plugin("jetbrains-dokka", "org.jetbrains.dokka").version(dokkaVersion)


### PR DESCRIPTION
## Summary of changes:

- Followed the official "[Installing and onboarding Renovate into repositories](https://docs.renovatebot.com/getting-started/installing-onboarding/)" guide.
    - Used [Renovate installer for Github](https://github.com/apps/renovate) hosted projects: 
    - Created a `renovate.json` file in our root repository.
        - Added some custom configs to match our desired requirements.
        - Set it to run after 5 pm on Saturday and Sunday (weekends).
        - Enabled dependency dashboard.
        - Major versions are manually approved before merge.