### PR TITLE
Update CC badge as it's returning 503

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Propactive
 
 [![CICD](https://github.com/u-ways/propactive/actions/workflows/CICD.yml/badge.svg)](https://github.com/u-ways/propactive/actions/workflows/CICD.yml)
-[![Code Climate](https://codeclimate.com/github/propactive/propactive.png)](https://codeclimate.com/github/propactive/propactive)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/41c79fb24e8833b59a68/test_coverage)](https://codeclimate.com/github/propactive/propactive/test_coverage)
+[![Code Climate](https://badgen.net/badge/CodeClimate/A/green)](https://codeclimate.com/github/propactive/propactive)
 [![Latest Version](https://img.shields.io/github/v/release/U-ways/propactive)](https://github.com/u-ways/propactive/releases)
 [![GitHub License](https://badgen.net/badge/license/MIT/blue)](https://github.com/u-ways/propactive/blob/master/LICENSE)
 


### PR DESCRIPTION
It seems CC for OSS has been down for awhile:

<img width="740" height="493" alt="image" src="https://github.com/user-attachments/assets/a434b190-22ab-44e1-851a-23bcc9f282fb" />